### PR TITLE
Add `reviewType` field to review metadata

### DIFF
--- a/data/posts/20150202-reviews-pixies-bossanova.md
+++ b/data/posts/20150202-reviews-pixies-bossanova.md
@@ -34,6 +34,7 @@ blurb: Our first ever review. Reads like it too. In any case, the album can cert
 artistMBID: b6b2bb8d-54a9-491f-9607-7b546023b433
 albumMBID: e062f23a-ed81-3baf-8f24-8979fef060cc
 artistLink: https://pixies.kontraband.store/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20150208-reviews-the-chemical-brothers-dig-your-own-hole.md
+++ b/data/posts/20150208-reviews-the-chemical-brothers-dig-your-own-hole.md
@@ -33,6 +33,7 @@ blurb: The Chemical Brothers’ second album is likely to please a number of ele
 artistMBID: 1946a82a-f927-40c2-8235-38d64f50d043
 albumMBID: 69f4aa7f-d760-3890-bd2a-902fb9abe40b
 artistLink: https://merch.thechemicalbrothers.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20150215-reviews-spiritualized-ladies-and-gentleman-we-are-floating-in-space.md
+++ b/data/posts/20150215-reviews-spiritualized-ladies-and-gentleman-we-are-floating-in-space.md
@@ -33,6 +33,7 @@ blurb: A magnificent journey, with tortured themes, fragile vocals, irresistibly
 artistMBID: 65041e06-83d2-4987-ae52-c17a915fc82a
 albumMBID: c88c77da-b9f9-34b9-abdf-ad3cec875aca
 artistLink: https://spiritualized.kontraband.store/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20150222-reviews-the-kinks-arthur.md
+++ b/data/posts/20150222-reviews-the-kinks-arthur.md
@@ -33,6 +33,7 @@ blurb: The songs are beautiful in ways only Ray Davies can achieve, but the albu
 artistMBID: 17b53d9f-5c63-4a09-a593-dde4608e0db9
 albumMBID: cd27ba91-162e-3d8a-8042-9451b84aa78e
 artistLink: https://store.thekinks.info/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20150301-reviews-pink-floyd-the-dark-side-of-the-moon.md
+++ b/data/posts/20150301-reviews-pink-floyd-the-dark-side-of-the-moon.md
@@ -36,6 +36,7 @@ blurb: The Dark Side of the Moon is one of those high-water marks of artistic ex
 artistMBID: 83d91898-7763-47d7-b03b-b92132375c47
 albumMBID: f5093c06-23e3-404f-aeaa-40f72885ee3a
 artistLink: https://www.pinkfloyd.com/store.php
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20150308-reviews-nine-inch-nails-the-downward-spiral.md
+++ b/data/posts/20150308-reviews-nine-inch-nails-the-downward-spiral.md
@@ -36,6 +36,7 @@ blurb: Trent Reznor set a benchmark in the industrial rock genre whilst simultan
 artistMBID: b7ffd2af-418f-4be2-bdd1-22f8b48613da
 albumMBID: 7c4cab8d-dead-3870-b501-93c90fd0a580
 artistLink: https://store.nin.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20150315-reviews-tom-waits-rain-dogs.md
+++ b/data/posts/20150315-reviews-tom-waits-rain-dogs.md
@@ -33,6 +33,7 @@ blurb: Rain Dogs isn’t for everyone, but if you want to hear what the roots of
 artistMBID: c3aeb863-7b26-4388-94e8-5a240f2be21b
 albumMBID: fb25a883-2270-3ec4-8c62-85c7ed857e6f
 artistLink: https://kingsroadmerch.com/tom-waits/region/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20150322-reviews-kendrick-lamar-to-pimp-a-butterfly.md
+++ b/data/posts/20150322-reviews-kendrick-lamar-to-pimp-a-butterfly.md
@@ -36,6 +36,7 @@ blurb: If Good Kid, M.A.A.D City introduced Kendrick Lamar to the masses, To Pim
 artistMBID: 381086ea-f511-4aba-bdf9-71c753dc5077
 albumMBID: d9103c72-3807-4378-9ce7-b6f3e8fdd547
 artistLink: https://shop.kendricklamar.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20150329-reviews-new-order-power-corruption-and-lies.md
+++ b/data/posts/20150329-reviews-new-order-power-corruption-and-lies.md
@@ -33,6 +33,7 @@ blurb: The catchy riffs and toe-tapping beats are there, but that's precisely th
 artistMBID: f1106b17-dcbb-45f6-b938-199ccfab50cc
 albumMBID: 16cc9dfc-594d-3fb9-b789-3e1bfcb6f9f8
 artistLink: https://store.neworder.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20150404-reviews-death-grips-the-powers-that-b.md
+++ b/data/posts/20150404-reviews-death-grips-the-powers-that-b.md
@@ -33,6 +33,7 @@ blurb: A lot of The Power That B seems like it shouldn't work, and yet it does. 
 artistMBID: f9133036-ab3d-4e97-bd11-7a2c98ad148a
 albumMBID: 6a1c9684-18c6-4b43-bd15-6badbbdc0600
 artistLink: https://deathgripsshop.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20150411-reviews-u2-the-joshua-tree.md
+++ b/data/posts/20150411-reviews-u2-the-joshua-tree.md
@@ -33,6 +33,8 @@ blurb: With a vast and powerful sound, here we experience U2 without the excruci
 artistMBID: a3cb23fc-acd3-4ce0-8f36-1e5aa6a18432
 albumMBID: 6f3e9fa6-be7a-3de8-a2b2-2072ece8a54d
 artistLink: https://shop.u2.com/
+reviewType: retrospective
+
 ---
 
 author: andre-dack

--- a/data/posts/20150418-reviews-squarepusher-damogen-furies.md
+++ b/data/posts/20150418-reviews-squarepusher-damogen-furies.md
@@ -33,6 +33,7 @@ blurb: Squarepusher produces another solid album without pushing any boundaries.
 artistMBID: 4d86ad4e-28d8-4e9f-8cf4-735c57060fdc
 albumMBID: 42e5557d-1c2e-4b1d-8580-7524ef8c3fd4
 artistLink: https://shop.squarepusher.net/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20150425-reviews-gorillaz-demon-days.md
+++ b/data/posts/20150425-reviews-gorillaz-demon-days.md
@@ -35,6 +35,7 @@ blurb: A cartoonish odyssey bristling with creative energy. The whimsy of the ba
 artistMBID: e21857d5-3256-4547-afb3-4b6ded592596
 albumMBID: f959a46a-a136-3134-9412-6572b23fad95 
 artistLink: https://store.gorillaz.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20150502-reviews-blur-the-magic-whip.md
+++ b/data/posts/20150502-reviews-blur-the-magic-whip.md
@@ -33,6 +33,7 @@ blurb: A rather unbalanced comeback that relies too heavily on its somber tone, 
 artistMBID: ba853904-ae25-4ebb-89d6-c44cfbd71bd2
 albumMBID: f8a42780-5eb1-43be-9a3f-4d3b80184300
 artistLink: https://shop.blur.co.uk/
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20150509-reviews-the-beatles-revolver.md
+++ b/data/posts/20150509-reviews-the-beatles-revolver.md
@@ -34,6 +34,7 @@ blurb: One of the most enjoyable pop albums of all time, an iconic work that wil
 artistMBID: b10bbbfc-cf9e-42e0-be17-e2c3e1d2600d
 albumMBID: 72d15666-99a7-321e-b1f3-a3f8c09dff9f
 artistLink: https://www.thebeatles.com/store/
+reviewType: retrospective
 
 ---
 author: andre-dack

--- a/data/posts/20150516-reviews-san-fermin-jackrabbit.md
+++ b/data/posts/20150516-reviews-san-fermin-jackrabbit.md
@@ -33,6 +33,7 @@ blurb: Flowing beautifully from beginning to end, the album in its entirety can 
 artistMBID: 1213b8e7-79f0-4cc2-a12a-81448aaf3429
 albumMBID: 47b984ae-646e-4bb0-9791-948c7a8a3a68
 artistLink: https://sanferminband.square.site/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20150523-reviews-muse-origin-of-symmetry.md
+++ b/data/posts/20150523-reviews-muse-origin-of-symmetry.md
@@ -34,6 +34,7 @@ blurb: There are few better highs than Muse in top gear. It’s breathless, expl
 artistMBID: 9c9f1380-2516-4fc9-a3e6-f9f61941d090
 albumMBID: ef03fe86-b54c-3667-8768-029833e7e1cd
 artistLink: https://store.muse.mu/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20150530-reviews-muse-drones.md
+++ b/data/posts/20150530-reviews-muse-drones.md
@@ -35,6 +35,7 @@ blurb: The opening third is nothing to write home about, the middle section is t
 artistMBID: 9c9f1380-2516-4fc9-a3e6-f9f61941d090
 albumMBID: 3133d4d5-5cfb-4f53-87f5-f3a97c8f310d
 artistLink: https://store.muse.mu/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20150606-reviews-neil-young-on-the-beach.md
+++ b/data/posts/20150606-reviews-neil-young-on-the-beach.md
@@ -34,6 +34,7 @@ blurb: On The Beach is perfect for those late nights alone. Both mellow and desp
 artistMBID: 75167b8b-44e4-407b-9d35-effe87b223cf
 albumMBID: f4174531-b783-3786-b75f-4fe61a8f6333
 artistLink: https://neilyoung.warnerrecords.com/
+reviewType: retrospective
 
 ---
 author: andre-dack

--- a/data/posts/20150613-reviews-jaga-jazzist-starfire.md
+++ b/data/posts/20150613-reviews-jaga-jazzist-starfire.md
@@ -32,6 +32,7 @@ blurb: A model of casual listening. It bustles along quite happily, from section
 artistMBID: 5c71ea68-9238-4dfc-8519-bd6eff6bc28b
 albumMBID: 09aad2c2-1eba-43b0-a591-d2ce7fdfa8ef
 artistLink: https://jagajazzist.bandcamp.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20150704-reviews-bob-marley-and-the-wailers-exodus.md
+++ b/data/posts/20150704-reviews-bob-marley-and-the-wailers-exodus.md
@@ -30,6 +30,7 @@ blurb: Peaks are matched by (very pleasant) plateaus. Exodus isn't so much a gre
 artistMBID: c296e10c-110a-4103-9e77-47bfebb7fb2e
 albumMBID: c5650313-60f3-34d3-92e4-300545133792
 artistLink: https://shop.bobmarley.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20150801-reviews-wolf-alice-my-love-is-cool.md
+++ b/data/posts/20150801-reviews-wolf-alice-my-love-is-cool.md
@@ -33,6 +33,7 @@ blurb: A record that’s unabashed and vibrant and full of potential. Wolf Alice
 artistMBID: 3547f34a-db02-4ab7-b4a0-380e1ef951a9
 albumMBID: e1085098-3b62-430f-b6c3-7a23eb6fecf3
 artistLink: https://store.wolfalice.co.uk/
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20150808-reviews-david-bowie-low.md
+++ b/data/posts/20150808-reviews-david-bowie-low.md
@@ -35,6 +35,7 @@ blurb: Bite-sized servings of vintage Bowie glam-rock combine with brooding inst
 artistMBID: 5441c29d-3602-4898-b1a1-b77fa23b8e50
 albumMBID: f6a51281-56c4-3538-b915-65a9d4eb29b5
 artistLink: https://store.davidbowie.com/
+reviewType: retrospective
 
 ---
 author: andre-dack

--- a/data/posts/20150822-reviews-lianne-la-havas-blood.md
+++ b/data/posts/20150822-reviews-lianne-la-havas-blood.md
@@ -34,6 +34,7 @@ blurb: For all the merits of Lianne La Havas’s thoroughly lovely and dynamic v
 artistMBID: 680466d6-f05b-44f6-858d-625d1b5087f6
 albumMBID: b6aa9a85-6dbd-42a2-8314-62e3070299d0
 artistLink: https://www.liannelahavas.com/merch/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20150825-reviews-public-image-ltd-9.md
+++ b/data/posts/20150825-reviews-public-image-ltd-9.md
@@ -30,6 +30,7 @@ blurb: It isn’t a classic, it isn’t conventional, it’s oftentimes a bit da
 artistMBID: 68950696-ee9a-49b2-a8c2-d1d6c19355cc
 albumMBID: 8b6dd34a-91fd-3b57-bc6d-cc660d176edb
 artistLink: https://store.universalmusic.com/PiL/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20151010-reviews-dr-dre-compton.md
+++ b/data/posts/20151010-reviews-dr-dre-compton.md
@@ -33,6 +33,7 @@ blurb: A polished, lumbering beast of an album. Not so much concerned with peaks
 artistMBID: 5f6ab597-f57a-40da-be9e-adad48708203
 albumMBID: 0f7a9bb0-c99a-48ea-93fb-ecdcc0ed636e
 artistLink: https://www.drdre.com/store
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20151014-reviews-the-strokes-first-impressions-of-earth.md
+++ b/data/posts/20151014-reviews-the-strokes-first-impressions-of-earth.md
@@ -33,6 +33,7 @@ blurb: A model misunderstood album; flawed, overdrawn, deserving of a good deal 
 artistMBID: f181961b-20f7-459e-89de-920ef03c7ed0
 albumMBID: 5ef51a9b-55eb-3400-99a8-47b892e11df7
 artistLink: https://shop.thestrokes.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20151019-reviews-sexwitch-sexwitch.md
+++ b/data/posts/20151019-reviews-sexwitch-sexwitch.md
@@ -32,6 +32,7 @@ blurb: Impressive vocal performances and a hugely gratifying tribal rhythm secti
 artistMBID: 2f0a5dae-f331-485a-b467-b3c9d41f490d
 albumMBID: 323d699e-83b0-4baf-8c2a-49be22ed42fe
 artistLink: https://www.musicglue.com/sexwitch/shop
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20151101-reviews-moby-18.md
+++ b/data/posts/20151101-reviews-moby-18.md
@@ -31,6 +31,7 @@ blurb: Strung together with downtempo drum beats, silky basslines, warming pads,
 artistMBID: 8970d868-0723-483b-a75b-51088913d3d4
 albumMBID: f83ca650-ae20-3347-ba06-5eaa9ab163af
 artistLink: https://store.moby.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20151107-reviews-joanna-newsom-divers.md
+++ b/data/posts/20151107-reviews-joanna-newsom-divers.md
@@ -30,7 +30,8 @@ week: 30
 blurb: A world both wonderful and despairing. Such dainty music will inevitably turn certain audiences away, which is a shame because, frankly, Divers is a triumph.
 artistMBID: cb69e1f1-bc76-4df5-93c9-cf97dd8a3b5c
 albumMBID: 099da227-07ea-42fd-b46e-9e1938fe18d3
-artistLink: https://www.dragcity.com/artists/joanna-newsom 
+artistLink: https://www.dragcity.com/artists/joanna-newsom
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20151116-reviews-st-vincent-st-vincent.md
+++ b/data/posts/20151116-reviews-st-vincent-st-vincent.md
@@ -35,6 +35,7 @@ blurb: Capturing the middle ground between passion and precision, Annie Clark’
 artistMBID: 5334edc0-5faf-4ca5-b1df-000de3e1f752
 albumMBID: 37889165-4443-4248-abd0-3c1703d9c02a
 artistLink: https://store.ilovestvincent.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20151127-reviews-oneohtrix-point-never-garden-of-delete.md
+++ b/data/posts/20151127-reviews-oneohtrix-point-never-garden-of-delete.md
@@ -34,6 +34,7 @@ blurb: Twisting and turning and purposely blindsiding its listeners, Garden of D
 artistMBID: 9cea062d-d476-447f-98b4-e67e14bfd1e4
 albumMBID: 5acba13f-0e96-4119-856a-6cd561ccd694
 artistLink: https://kontraband.shop/collections/point-never
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20151202-reviews-james-blake-overgrown.md
+++ b/data/posts/20151202-reviews-james-blake-overgrown.md
@@ -31,6 +31,7 @@ blurb: It’s beautifully discreet, formed with an elegance that pushes it to th
 artistMBID: 8dc08b1f-e393-4f85-a5dd-300f7693a8b8
 albumMBID: b9a4e9ad-400c-4219-ae45-519c2d8167f7
 artistLink: https://shop.jamesblakemusic.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20151209-reviews-adele-25.md
+++ b/data/posts/20151209-reviews-adele-25.md
@@ -32,6 +32,7 @@ blurb: Inoffensive and unspectacular pop fodder. People will listen to it on the
 artistMBID: cc2c9c3c-b7bc-4b8b-84d8-4fbd8779e493
 albumMBID: 5537624c-3d2f-4f5c-8099-df916082c85c
 artistLink: https://shop.adele.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20151216-reviews-queens-of-the-stone-age-like-clockwork.md
+++ b/data/posts/20151216-reviews-queens-of-the-stone-age-like-clockwork.md
@@ -34,6 +34,8 @@ blurb: Homme’s quip that rock 'should be heavy enough for the boys and sweet e
 artistMBID: 7dc8f5bd-9d0b-4087-9f73-dc164950bbd8
 albumMBID: c92f73ee-527f-42ed-a556-fd615941e214
 artistLink: https://store.qotsa.com/
+reviewType: retrospective
+
 ---
 
 author: andre-dack

--- a/data/posts/20160113-reviews-david-bowie-blackstar.md
+++ b/data/posts/20160113-reviews-david-bowie-blackstar.md
@@ -35,6 +35,7 @@ blurb: A portal into the world of remembrances that grief gives birth to... and 
 artistMBID: 5441c29d-3602-4898-b1a1-b77fa23b8e50
 albumMBID: 1fd18f5b-9a92-41fd-a590-da6b5cc60d85
 artistLink: https://store.davidbowie.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20160120-reviews-weezer-the-blue-album.md
+++ b/data/posts/20160120-reviews-weezer-the-blue-album.md
@@ -35,6 +35,8 @@ blurb: Weezer were unapologetically weird, yet strangely glamorous, which in its
 artistMBID: 6fe07aa5-fec0-4eca-a456-f29bff451b04
 albumMBID: c7b245c9-8099-32ea-af95-893acedde2cf
 artistLink: https://weezerwebstore.com
+reviewType: retrospective
+
 ---
 
 author: andre-dack

--- a/data/posts/20160127-reviews-savages-adore-life.md
+++ b/data/posts/20160127-reviews-savages-adore-life.md
@@ -33,6 +33,7 @@ blurb: The vitality that makes Savages so appealing is too often replaced by a s
 artistMBID: 42d72c29-8a7a-4c88-89ed-a2ca25d40284
 albumMBID: ea9d35e8-bec7-43e8-96b1-3a6e9eb7295a
 artistLink: https://matadorrecords.com/savages
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20160203-reviews-arcade-fire-funeral.md
+++ b/data/posts/20160203-reviews-arcade-fire-funeral.md
@@ -35,6 +35,7 @@ blurb: Funeral is the beating heart of adolescence, a journey that voices the st
 artistMBID: 52074ba6-e495-4ef3-9bb4-0703888a9f68
 albumMBID: 05affa96-5959-32da-8d75-1c9eb985ca59
 artistLink: https://www.arcadefirestore.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20160210-reviews-saul-williams-martyr-loser-king.md
+++ b/data/posts/20160210-reviews-saul-williams-martyr-loser-king.md
@@ -33,6 +33,7 @@ blurb: While there’s little wrong with any of the cuts, the album in its entir
 artistMBID: 756cf672-d4ae-4470-a3af-a43d776a211d
 albumMBID: 95846af2-4189-4049-879b-25af1852bf91
 artistLink: http://saulwilliams.com/store/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20160217-reviews-portishead-dummy.md
+++ b/data/posts/20160217-reviews-portishead-dummy.md
@@ -35,6 +35,8 @@ blurb: Melding orchestral and jazz samples with beats that surge tracks forward,
 artistMBID: 8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11
 albumMBID: 48140466-cff6-3222-bd55-63c27e43190d
 artistLink: https://shop.portishead.co.uk/
+reviewType: retrospective
+
 ---
 
 author: andre-dack

--- a/data/posts/20160224-reviews-kanye-west-the-life-of-pablo.md
+++ b/data/posts/20160224-reviews-kanye-west-the-life-of-pablo.md
@@ -34,6 +34,7 @@ blurb: Uneven, sporadic, and totally erratic; an unfinished version of a potenti
 artistMBID: 164f0d73-1234-4e2c-8743-d77bf2191051
 albumMBID: 8c18657a-6338-490d-a952-897663596b96
 artistLink: https://shop.kanyewest.com
+reviewType: newRelease
 
 ---
 
@@ -44,9 +45,9 @@ review: >-
   
   Kanye West has essentially attempted to sell his undeveloped ideas as substantial concepts, resulting in a complete lack of cohesion. Tracks are often compelling at first, only to then erratically detour onto something else. Though they’re not necessarily the finest cuts here, the great thing about “Feedback”, “Freestyle 4”, and “Facts” is that they allow you to simply listen to and enjoy Kanye’s excellent delivery without needing to pay much attention to the lesser lyrical lines. 
   
-  The best tracks are those that actually offer self-examinations of his humanity, such as “Real Friends” and “No More Parties in LA”, and those that display Kanye’s lunacy just enough to sound delightfully eccentric. It’s unfortunately the other side of his unpredictable narcissism that prevents *TLoP* from being a complete and satisfying album. For every “Real Friends”, there’s a “Waves”; for every “Feedback”, there’s a “30 Hours”; for every short piece of sweet spontaneity, there’s an unnecessary skit of insufferable nonsense. 
+  The best tracks are those that actually offer self-examinations of his humanity, such as “Real Friends” and “No More Parties in LA”, and those that display Kanye’s lunacy just enough to sound delightfully eccentric. It’s unfortunately the other side of his unpredictable narcissism that prevents *TLoP* from being a complete and satisfying album. For every “Real Friends”, there’s a “Waves”; for every “Feedback”, there’s a “30 Hours”; for every short piece of sweet spontaneity, there’s an unnecessary skit of insufferable nonsense.
   
-  Perhaps I’m missing the point, and maybe I’m taking it too seriously, but in my mind *TLoP* is just a heap of hype that leisurely rides the persona of Kanye West to the very maximum. It probably succeeds as entertainment — I’m just yet to be convinced that it’s genuinely a good record. Despite its enjoyable moments, of which there is a sizable amount, *TLoP* stands as Kanye’s most disappointing, laziest effort yet.
+  Perhaps I’m missing the point, and maybe I’m taking it too seriously, but in my mind *TLoP* is just a heap of hype that leisurely rides the persona of Kanye West to the very maximum. It probably succeeds as entertainment — I’m just yet to be convinced that it’s genuinely a good record. Despite its enjoyable moments, of which there is a sizable amount, *TLoP* stands as Kanye’s most disappointing, laziest effort yet.
 
 tracks:
   - Real Friends
@@ -80,9 +81,9 @@ tracks:
   - ­I Love Kanye
 
 score:
-  score: 30
+  score: 7
   max: 10
-  fraction: 3
+  fraction: 0.7
 
 ---
 

--- a/data/posts/20160302-reviews-john-lennon-john-lennon-plastic-ono-band.md
+++ b/data/posts/20160302-reviews-john-lennon-john-lennon-plastic-ono-band.md
@@ -34,6 +34,8 @@ blurb: Raw, deeply personal, and tremendously honest, this was rock & roll as Le
 artistMBID: 4d5447d7-c61c-4120-ba1b-d7f471d385b9
 albumMBID: 8be83468-4917-390d-82b6-d890f058cd22
 artistLink: https://store.johnlennon.com
+reviewType: retrospective
+
 ---
 
 author: andre-dack

--- a/data/posts/20160309-reviews-kendrick-lamar-untitled-unmastered.md
+++ b/data/posts/20160309-reviews-kendrick-lamar-untitled-unmastered.md
@@ -31,6 +31,7 @@ blurb: Comprised mostly of dabbles and snippets from the formative months of To 
 artistMBID: 381086ea-f511-4aba-bdf9-71c753dc5077
 albumMBID: 4e44335c-3f2b-4874-a6c3-71b5e65f75d5
 artistLink: https://shop.kendricklamar.com
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20160316-reviews-jarvis-cocker-jarvis.md
+++ b/data/posts/20160316-reviews-jarvis-cocker-jarvis.md
@@ -33,6 +33,7 @@ blurb: This is pop music for the mature listener; easy to consume, enjoyable eno
 artistMBID: 38550441-d437-4aff-867e-e79bf0c04142
 albumMBID: 8f4857ed-2ca3-4931-b5ca-04556ea5160f
 artistLink: https://jarvis-uk.myshopify.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20160323-reviews-iggy-pop-post-pop-depression.md
+++ b/data/posts/20160323-reviews-iggy-pop-post-pop-depression.md
@@ -32,6 +32,7 @@ blurb: A solid Iggy Pop record, but with a lingering sense of disappointment tha
 artistMBID: f37b3f31-b1f8-4b88-8cb5-b34f709b17d7
 albumMBID: 4277f167-a71e-46bb-a69e-439dcd5a37e2
 artistLink: https://shop.postpopdepression.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20160330-reviews-thom-yorke-the-eraser.md
+++ b/data/posts/20160330-reviews-thom-yorke-the-eraser.md
@@ -33,6 +33,7 @@ blurb: The Eraser is a wonderful listen that comes with some baggage. If you’r
 artistMBID: 8ed2e0b3-aa4c-4e13-bec3-dc7393ed4d6b
 albumMBID: 2a971a81-2f4d-333b-8327-8b2d73c649cf
 artistLink: https://store.wasteheadquarters.com/collections/thom-yorke-atoms-for-peace/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20160406-reviews-mogwai-atomic.md
+++ b/data/posts/20160406-reviews-mogwai-atomic.md
@@ -33,6 +33,7 @@ blurb: Atomic can be exhausting, but in a manner that exhilarates rather than dr
 artistMBID: d700b3f5-45af-4d02-95ed-57d301bda93e
 albumMBID: abf559f9-8c52-4295-9b8c-79b72f8d9837
 artistLink: https://store.mogwai.scot/
+reviewType: newRelease
 ---
 
 author: andre-dack

--- a/data/posts/20160413-reviews-major-lazer-free-the-universe.md
+++ b/data/posts/20160413-reviews-major-lazer-free-the-universe.md
@@ -30,6 +30,7 @@ blurb: Formulaic songwriting; a complete absence of dynamics; a detachment in st
 artistMBID: 75be165a-ad83-4d12-bd28-f589a15c479f
 albumMBID: 924327d2-b64d-4759-b382-905e6cd417c0
 artistLink: https://majorlazer.merchtable.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20160420-reviews-pj-harvey-the-hope-six-demolition-project.md
+++ b/data/posts/20160420-reviews-pj-harvey-the-hope-six-demolition-project.md
@@ -34,6 +34,7 @@ blurb: A capacious sequel that seems confused by its own message. It neither sin
 artistMBID: e795e03d-b5d5-4a5f-834d-162cfb308a2c
 albumMBID: 805f6d35-5841-4339-9ee3-fa6ef9afa890
 artistLink: https://pjharvey.kontraband.store/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20160427-reviews-deftones-gore.md
+++ b/data/posts/20160427-reviews-deftones-gore.md
@@ -33,6 +33,7 @@ blurb: Without sacrificing the brutality fans have come to expect from Deftones,
 artistMBID: 7527f6c2-d762-4b88-b5e2-9244f1e34c46
 albumMBID: 4c0a6c9b-090b-4159-a359-a328d94c50d3
 artistLink: https://deftones.merchdirect.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20160504-reviews-prince-purple-rain.md
+++ b/data/posts/20160504-reviews-prince-purple-rain.md
@@ -33,6 +33,7 @@ blurb: An endearing record of mystery and wonder, deftly inheriting elements fro
 artistMBID: 070d193a-845c-479f-980e-bef15710653e
 albumMBID: b93a7c47-a6d4-33f2-9034-53fdd991f4ba
 artistLink: https://store.prince.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20160511-reviews-james-blake-the-colour-in-anything.md
+++ b/data/posts/20160511-reviews-james-blake-the-colour-in-anything.md
@@ -31,6 +31,7 @@ blurb: For an album that clocks in well over the hour mark, it’s regrettably u
 artistMBID: 8dc08b1f-e393-4f85-a5dd-300f7693a8b8
 albumMBID: bd166f52-cc11-4554-8045-ada94e6b2911
 artistLink: https://shop.jamesblakemusic.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20160518-reviews-radiohead-a-moon-shaped-pool.md
+++ b/data/posts/20160518-reviews-radiohead-a-moon-shaped-pool.md
@@ -37,6 +37,7 @@ blurb: A daunting experience that revels in its sorrow. Radiohead have produced 
 artistMBID: a74b1b7f-71a5-4011-9441-d0b5e4122711
 albumMBID: bbce0087-d386-4246-a51d-dbcdfdbe8fb2
 artistLink: https://store.wasteheadquarters.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20160525-reviews-radiohead-ok-computer.md
+++ b/data/posts/20160525-reviews-radiohead-ok-computer.md
@@ -40,6 +40,7 @@ blurb: To brand this a landmark of the '90s is a disservice to its quality. OK C
 artistMBID: a74b1b7f-71a5-4011-9441-d0b5e4122711
 albumMBID: b1392450-e666-3926-a536-22c65f834433
 artistLink: https://store.wasteheadquarters.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20160608-reviews-rob-heron-and-the-tea-pad-orchestra-something-blue.md
+++ b/data/posts/20160608-reviews-rob-heron-and-the-tea-pad-orchestra-something-blue.md
@@ -33,6 +33,7 @@ blurb: Brimming with catchy vocal hooks and harmonious moments, Something Blue i
 artistMBID: 19b1e7e2-b1ee-44ea-9ea9-cc2289e66f5f
 albumMBID: c880b630-bc60-43c5-82cb-2e2384c6b133
 artistLink: https://teapadorchestra.bigcartel.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20160615-reviews-nas-illmatic.md
+++ b/data/posts/20160615-reviews-nas-illmatic.md
@@ -30,6 +30,7 @@ blurb: Illmatic has every element required that goes into making a great hip-hop
 artistMBID: cfbc0924-0035-4d6c-8197-f024653af823
 albumMBID: 28298e2c-4d70-3eed-a0f5-a3280c662b3d
 artistLink: https://shop.nasirjones.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20160622-reviews-swans-the-glowing-man.md
+++ b/data/posts/20160622-reviews-swans-the-glowing-man.md
@@ -32,6 +32,7 @@ blurb: The Glowing Man is a rewarding experience, if not always a pleasant one. 
 artistMBID: 3285dc48-9505-469d-ad8a-bdf2d3dba632
 albumMBID: 3e6586d2-46ce-4d75-b9bb-b3c6f422a8d2
 artistLink: https://swans.bandcamp.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20160629-reviews-talking-heads-remain-in-light.md
+++ b/data/posts/20160629-reviews-talking-heads-remain-in-light.md
@@ -35,6 +35,7 @@ blurb: Under the Midas wing of Brian Eno, Talking Heads juggle African genres wi
 artistMBID: a94a7155-c79d-4409-9fcf-220cb0e4dc3a
 albumMBID: f6b1b900-6108-32f0-abbd-2855af9151eb
 artistLink: https://hifi247.com/talking-heads.html
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20160706-reviews-bat-for-lashes-the-bride.md
+++ b/data/posts/20160706-reviews-bat-for-lashes-the-bride.md
@@ -33,6 +33,7 @@ blurb: This was 50 minutes of anti-climax. Interesting instrumentals are peppere
 artistMBID: 10000730-525f-4ed5-aaa8-92888f060f5f
 albumMBID: 299408a0-9846-4234-9d1e-559a5d54f8df
 artistLink: https://www.batforlashes.com/shop
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20160713-reviews-the-avalanches-wildflower.md
+++ b/data/posts/20160713-reviews-the-avalanches-wildflower.md
@@ -32,6 +32,7 @@ blurb: Wildflower brims with positive energy, and is a worthy, if lopsided follo
 artistMBID: a6623d39-2d8e-4f70-8242-0a9553b91e50
 albumMBID: e27e2c64-8e49-43d2-8468-c3b484cf11f0
 artistLink: https://artists.sound-merch.com.au/theavalanches/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20160720-reviews-the-jimi-hendrix-experience-electric-ladyland.md
+++ b/data/posts/20160720-reviews-the-jimi-hendrix-experience-electric-ladyland.md
@@ -35,6 +35,7 @@ blurb: Instinctive, messy, and rambling, with shimmers of the divine. Electric L
 artistMBID: 33b3c323-77c2-417c-a5b4-af7e6a111cc9
 albumMBID: 47ba2d59-5544-34a4-b108-dc08c0956298
 artistLink: https://www.authentichendrix.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20160727-reviews-g-love-and-special-sauce-g-love-and-special-sauce.md
+++ b/data/posts/20160727-reviews-g-love-and-special-sauce-g-love-and-special-sauce.md
@@ -32,6 +32,7 @@ blurb: The album is ice-cool summer groove music, with shimmering guitar stabs, 
 artistMBID: dbf7c761-e332-467b-b4d9-aafe06bbcf8f
 albumMBID: d54dc508-1b22-3922-8839-6ddcfff10b7d
 artistLink: https://philadelphonic.com/shop/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20160803-reviews-daft-punk-discovery.md
+++ b/data/posts/20160803-reviews-daft-punk-discovery.md
@@ -32,6 +32,7 @@ blurb: Discovery is a classic dance albums despite its age and the progression w
 artistMBID: 056e4f3e-d505-4dad-8ec1-d04f521cbb56
 albumMBID: 48117b90-a16e-34ca-a514-19c702df1158
 artistLink: https://daftpunk.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20160810-reviews-eels-daisies-of-the-galaxy.md
+++ b/data/posts/20160810-reviews-eels-daisies-of-the-galaxy.md
@@ -34,6 +34,7 @@ blurb: Daisies of the Galaxy comes to terms with the torment that constructed th
 artistMBID: 14387b0f-765c-4852-852f-135335790466
 albumMBID: ea5f23b9-55b0-3838-b25f-88a9eaf4addb
 artistLink: https://eelstheband.com/stores.php
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20160817-reviews-the-smashing-pumpkins-gish.md
+++ b/data/posts/20160817-reviews-the-smashing-pumpkins-gish.md
@@ -37,6 +37,7 @@ blurb: The record is a rich and gloriously grubby collage of sounds. It stands s
 artistMBID: ba0d6274-db14-4ef5-b28d-657ebde1a396
 albumMBID: 4ac82f0b-1532-3734-80d7-5c02265197aa
 artistLink: https://store.smashingpumpkins.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20160824-reviews-fat-freddys-drop-based-on-a-true-story.md
+++ b/data/posts/20160824-reviews-fat-freddys-drop-based-on-a-true-story.md
@@ -30,6 +30,7 @@ blurb: True to its reggae roots, Based on a True Story's mood is consistently me
 artistMBID: d451395a-f768-432e-bb70-d38c32baf4cb
 albumMBID: a90009fd-94d1-37f7-aa0a-8c59c0ad1f60
 artistLink: https://shop.fatfreddysdrop.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20160831-reviews-frank-ocean-blond.md
+++ b/data/posts/20160831-reviews-frank-ocean-blond.md
@@ -39,6 +39,7 @@ blurb: Blond flirts with indulgence but just about manages to stay grounded. Itâ
 artistMBID: e520459c-dff4-491d-a6e4-c97be35e0044
 albumMBID: 0da340a0-6ad7-4fc2-a272-6f94393a7831
 artistLink: https://blonded.co/
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20160907-reviews-frank-ocean-channel-orange.md
+++ b/data/posts/20160907-reviews-frank-ocean-channel-orange.md
@@ -33,6 +33,7 @@ blurb: Shifting smoothly from ’90s R&B to psychedelic funk, Channel Orange is 
 artistMBID: e520459c-dff4-491d-a6e4-c97be35e0044
 albumMBID: f8f4167d-897c-4b25-a171-638374d1dfa4
 artistLink: https://blonded.co/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20160914-reviews-mia-aim.md
+++ b/data/posts/20160914-reviews-mia-aim.md
@@ -33,6 +33,7 @@ blurb: M.I.A.’s fifth and final album is an unfortunate affair. Comprised of l
 artistMBID: 7cf0ea9d-86b9-4dad-ba9e-2355a64899ea
 albumMBID: c5bf04b5-30ba-43b1-88a1-5395a4fdb430
 artistLink: http://miauniverse.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20160921-reviews-nick-cave-and-the-bad-seeds-skeleton-tree.md
+++ b/data/posts/20160921-reviews-nick-cave-and-the-bad-seeds-skeleton-tree.md
@@ -35,6 +35,7 @@ blurb: Tension lingers in every song. The record is defined by its desolate atmo
 artistMBID: 172e1f1a-504d-4488-b053-6344ba63e6d0
 albumMBID: 49339024-c6b4-4345-b521-6349463513cb
 artistLink: https://store.nickcave.com/
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20160928-reviews-preoccupations-preoccupations.md
+++ b/data/posts/20160928-reviews-preoccupations-preoccupations.md
@@ -38,6 +38,7 @@ blurb: It’s an intensely focused musical space, guided by a vocal delivery tha
 artistMBID: 9ee1988d-66ec-4c29-98d6-876a45e0fcbd
 albumMBID: 2a64e463-6d16-4ae4-af8d-f3c064b09256
 artistLink: https://preoccupations.bandcamp.com/merch
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20161005-reviews-bon-iver-22-a-million.md
+++ b/data/posts/20161005-reviews-bon-iver-22-a-million.md
@@ -37,6 +37,8 @@ blurb: 22, A Million feels like a nondescript blur. It doesn’t deal in structu
 artistMBID: 437a0e49-c6ae-42f6-a6c1-84f25ed366bc
 albumMBID: f0e8f425-a941-48df-b5d7-2ceeaaf77c71
 artistLink: https://store.boniver.org/
+reviewType: newRelease
+
 ---
 
 author: andre-dack

--- a/data/posts/20161012-reviews-solange-a-seat-at-the-table.md
+++ b/data/posts/20161012-reviews-solange-a-seat-at-the-table.md
@@ -32,6 +32,7 @@ blurb: An extremely smooth ride with no turbulence or unnecessary distractions, 
 artistMBID: 410e7fd3-b865-4fa0-bb18-1b7fd53382ca
 albumMBID: 331a7ba1-fae2-4881-b434-554f46c13746
 artistLink: https://solange.blackplanet.com/shop/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20161019-reviews-the-dillinger-escape-plan-dissociation.md
+++ b/data/posts/20161019-reviews-the-dillinger-escape-plan-dissociation.md
@@ -38,6 +38,7 @@ blurb: Furious metal rackets trade blows with soft, elegant jazz fusion and stri
 artistMBID: 1bc41dff-5397-4c53-bb50-469d2c277197
 albumMBID: 18c29ff8-b6bc-497e-a362-683978c2cdd2
 artistLink: https://store.relapse.com/b/the-dillinger-escape-plan
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20161026-reviews-lady-gaga-joanne.md
+++ b/data/posts/20161026-reviews-lady-gaga-joanne.md
@@ -34,6 +34,7 @@ blurb: Precious little of what makes Gaga special is on show in Joanne. Outrageo
 artistMBID: 650e7db6-b795-4eb5-a702-5ea2fc46c848
 albumMBID: b3d4aef6-749f-40c1-b8f0-e763bde8cfdc
 artistLink: https://shop.ladygaga.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20161102-reviews-the-flaming-lips-yoshimi-battles-the-pink-robots.md
+++ b/data/posts/20161102-reviews-the-flaming-lips-yoshimi-battles-the-pink-robots.md
@@ -33,6 +33,7 @@ blurb: The album functions best as a fantastical journey of curious thoughts and
 artistMBID: 1f43d76f-8edf-44f6-aaf1-b65f05ad9402
 albumMBID: 54b1ad4e-7e86-308d-b053-a0843f6abbdb
 artistLink: https://store.flaminglips.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20161109-reviews-jefferson-airplane-surrealistic-pillow.md
+++ b/data/posts/20161109-reviews-jefferson-airplane-surrealistic-pillow.md
@@ -35,6 +35,7 @@ blurb: A staple of the psychedelic folk-rock genre, feeling as fresh and vibrant
 artistMBID: 39c2a93d-9afa-4a22-9bba-c087ab056e1c
 albumMBID: e6440cd2-5e8e-367d-bc49-cc042b5ef524
 artistLink: https://jeffersonairplane.shop.musictoday.com
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20161116-reviews-a-tribe-called-quest-we-got-it-from-here-thank-you-4-your-service.md
+++ b/data/posts/20161116-reviews-a-tribe-called-quest-we-got-it-from-here-thank-you-4-your-service.md
@@ -30,7 +30,10 @@ week: 79
 blurb: The record certainly has that classic Tribe vibe, but it lacks the key finishing touches for it to be favourably compared to the material of the early ’90s.
 artistMBID: 9689aa5a-4471-4fb4-9721-07cecda0fa9f
 albumMBID: b445860f-edd9-4160-841c-fccf5533ecbd
+reviewType: newRelease
+
 ---
+
 author: andre-dack
 
 review: >-

--- a/data/posts/20161123-reviews-justice-woman.md
+++ b/data/posts/20161123-reviews-justice-woman.md
@@ -32,6 +32,7 @@ blurb: It lives and breathes like a reincarnation of disco. The melodies are inf
 artistMBID: 860b2707-6153-4e3a-aa57-74d2b42c55b5
 albumMBID: e295b8f2-a86c-49fb-8668-aaba1c9f9e4a
 artistLink: https://shop.justice.church/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20161130-reviews-rem-out-of-time.md
+++ b/data/posts/20161130-reviews-rem-out-of-time.md
@@ -32,6 +32,7 @@ blurb: The record warrants a listen for the highlights alone. The problems, such
 artistMBID: ea4dfa26-f633-4da6-a52a-f49ea4897b58
 albumMBID: 400a5fdd-e616-3598-a9bf-
 artistLink: https://store.remhq.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20161207-reviews-childish-gambino-awaken-my-love.md
+++ b/data/posts/20161207-reviews-childish-gambino-awaken-my-love.md
@@ -33,6 +33,7 @@ blurb: The album boasts a lush, colourful sound, drawing from elements of funk a
 artistMBID: 7fb57fba-a6ef-44c2-abab-2fa3bdee607e
 albumMBID: fd817615-3d43-4f07-9509-d0a46b2bc278
 artistLink: https://shop.childishgambino.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170201-reviews-bjork-homogenic.md
+++ b/data/posts/20170201-reviews-bjork-homogenic.md
@@ -35,6 +35,7 @@ blurb: Homogenic is a stunning work. Björk often defies categorisation, but her
 artistMBID: 87c5dedd-371d-4a53-9f7f-80522fb7f3cb
 albumMBID: 810272e0-aef1-3d85-b2d3-e512e87fc38c
 artistLink: https://shop.bjork.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20170208-reviews-elbow-little-fictions.md
+++ b/data/posts/20170208-reviews-elbow-little-fictions.md
@@ -31,6 +31,7 @@ blurb: Little Fictions is the sound of contentedness. It’s pleasant, it’s ge
 artistMBID: 3cb3928a-526c-4a3d-93c5-53315fa9bde0
 albumMBID: d4bea9d0-1cf1-4cb5-a823-f30e4722de88
 artistLink: https://store.universalmusic.com/elbow/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170215-reviews-of-montreal-hissing-fauna-are-you-the-destroyer.md
+++ b/data/posts/20170215-reviews-of-montreal-hissing-fauna-are-you-the-destroyer.md
@@ -34,6 +34,7 @@ blurb: There are a handful of stellar pop tracks, and a mammoth mid-album climax
 artistMBID: 8475297d-fb78-4630-8d74-9b87b6bb7cc8
 albumMBID: 4eacd95b-675a-3c6b-9d83-5d9360719f37
 artistLink: https://www.ofmontreal.net/shop
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20170222-reviews-arctic-monkeys-favourite-worst-nightmare.md
+++ b/data/posts/20170222-reviews-arctic-monkeys-favourite-worst-nightmare.md
@@ -34,6 +34,7 @@ blurb: Riffs in giant proportions, subtleties hidden between the pedal switches,
 artistMBID: ada7a83c-e3e1-40f1-93f9-3e73dbc9298a
 albumMBID: f113fa38-7908-3ec9-8145-d2455e78a8b2
 artistLink: https://arcticmonkeys-store.com
+reviewType: retrospective
 
 ---
 author: andre-dack

--- a/data/posts/20170301-reviews-thundercat-drunk.md
+++ b/data/posts/20170301-reviews-thundercat-drunk.md
@@ -33,6 +33,7 @@ blurb: Thundercat doesn’t want to exhaust an idea, getting in and out of a son
 artistMBID: 044fd265-79dd-43eb-afc4-8b20becf7e17
 albumMBID: f0c89a63-6cb0-4b5f-9ced-79396b58a191
 artistLink: https://thundercat.bandcamp.com
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170308-reviews-grandaddy-last-place.md
+++ b/data/posts/20170308-reviews-grandaddy-last-place.md
@@ -36,6 +36,7 @@ blurb: Some artists have a hard time returning after a lengthy hiatus, but Grand
 artistMBID: 9d4c4835-c71a-4647-a4fc-263e26832cd0
 albumMBID: 74bcd0ac-2a17-4030-9d71-69ecb6c9dd00
 artistLink: https://www.grandaddymusic.com/store
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170315-reviews-laura-marling-semper-femina.md
+++ b/data/posts/20170315-reviews-laura-marling-semper-femina.md
@@ -32,6 +32,7 @@ blurb: In today’s climate of formulaic acts dominating the charts, Laura Marli
 artistMBID: cd9713d6-6e5f-4143-9412-4d12b7bd47f2
 albumMBID: 3037f334-1e40-4d13-98ed-08169120652b
 artistLink: https://store.lauramarling.com/
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20170322-reviews-stevie-wonder-songs-in-the-key-of-life.md
+++ b/data/posts/20170322-reviews-stevie-wonder-songs-in-the-key-of-life.md
@@ -34,6 +34,7 @@ blurb: The jams are drawn out in a ceremonious manner, with hooks piled on top o
 artistMBID: 1ee18fb3-18a6-4c7f-8ba0-bc41cdd0462e
 albumMBID: ea88b09b-fd34-33cf-a3e5-25a3a2fb4c6f
 artistLink: https://www.merchbar.com/r-b-hiphop-rap/stevie-wonder
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20170329-reviews-soulwax-from-deewee.md
+++ b/data/posts/20170329-reviews-soulwax-from-deewee.md
@@ -31,6 +31,7 @@ blurb: Songs regularly start with promising grooves then go nowhere. Rhythmic re
 artistMBID: 68ec1b08-3c2e-40b3-b0af-8f323743fdff
 albumMBID: 950b2ca1-8cee-472f-ac91-86387c490f2c
 artistLink: https://store.soulwax.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170405-reviews-nirvana-in-utero.md
+++ b/data/posts/20170405-reviews-nirvana-in-utero.md
@@ -33,6 +33,7 @@ blurb: Cobain, Grohl, and Novoselic had an elemental chemistry, and their contro
 artistMBID: 5b11f4ce-a62d-471e-81fc-a69a8278c7da
 albumMBID: 2a0981fb-9593-3019-864b-ce934d97a16e
 artistLink: https://shop.nirvana.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20170412-reviews-san-fermin-belong.md
+++ b/data/posts/20170412-reviews-san-fermin-belong.md
@@ -33,6 +33,7 @@ blurb: Music written by a composer of Ellis Ludwig-Leone's class should never fe
 artistMBID: 1213b8e7-79f0-4cc2-a12a-81448aaf3429
 albumMBID: 58821ade-2219-4502-b362-6ec0b4b00d67
 artistLink: https://sanferminband.square.site/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170419-reviews-kendrick-lamar-damn.md
+++ b/data/posts/20170419-reviews-kendrick-lamar-damn.md
@@ -32,6 +32,7 @@ blurb: Kendrick explores a multitude of personal predicaments, but it's difficul
 artistMBID: 381086ea-f511-4aba-bdf9-71c753dc5077
 albumMBID: b88655ba-7469-48b8-a296-b9011ab73ef3
 artistLink: https://shop.kendricklamar.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170426-reviews-kings-of-leon-because-of-the-times.md
+++ b/data/posts/20170426-reviews-kings-of-leon-because-of-the-times.md
@@ -33,6 +33,7 @@ blurb: Because of the Times is laudable record with a plethora of well written t
 artistMBID: 6ffb8ea9-2370-44d8-b678-e9237bbd347b
 albumMBID: 20de4fa6-4cf7-31c1-b8f2-d5c46b754d07
 artistLink: https://store.digitalstores.co.uk/kingsofleon/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20170503-reviews-gorillaz-humanz.md
+++ b/data/posts/20170503-reviews-gorillaz-humanz.md
@@ -31,6 +31,7 @@ blurb: The album’s songwriting is fairly subpar, trying to say everything at o
 artistMBID: e21857d5-3256-4547-afb3-4b6ded592596
 albumMBID: 066f840f-e357-436f-bb0a-47ad7cfcd84a
 artistLink: https://store.gorillaz.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170504-reviews-run-the-jewels-run-the-jewels-2.md
+++ b/data/posts/20170504-reviews-run-the-jewels-run-the-jewels-2.md
@@ -33,6 +33,8 @@ blurb: "Growling beats, echoing synths, and dark use of space lend themselves we
 artistMBID: a80c5dc5-b12e-4667-9f5a-b568961f3839
 albumMBID: 581d7ac8-8f1d-4d4a-a224-de9c9cd76b39
 artistLink: https://rtj4.link/store/
+reviewType: retrospective
+
 ---
 
 author: andre-dack

--- a/data/posts/20170517-reviews-brian-eno-ambient-1-music-for-airports.md
+++ b/data/posts/20170517-reviews-brian-eno-ambient-1-music-for-airports.md
@@ -37,6 +37,7 @@ blurb: Music for Airports comprises of calming tones that induce sedation and tr
 artistMBID: ff95eb47-41c4-4f7f-a104-cdc30f02e872
 albumMBID: 5fdd6ba8-83c1-3a87-b378-d5f61dec5ddd
 artistLink: https://www.enoshop.co.uk/shop.html
+reviewType: retrospective
 
 ---
 author: andre-dack

--- a/data/posts/20170524-reviews-soundgarden-superunknown.md
+++ b/data/posts/20170524-reviews-soundgarden-superunknown.md
@@ -36,6 +36,7 @@ blurb: Superunknown is a sprawling record, spanning grunge, alternative metal, s
 artistMBID: 153c9281-268f-4cf3-8938-f5a4593e5df4
 albumMBID: 8300fe9c-0022-3c55-8a3e-8dc61f282e8c
 artistLink: https://shopuk.soundgardenworld.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20170531-reviews-pixies-doolittle.md
+++ b/data/posts/20170531-reviews-pixies-doolittle.md
@@ -35,6 +35,7 @@ blurb: Doolittle balances boisterous oddness with sweet and sugary pop tunes, ma
 artistMBID: b6b2bb8d-54a9-491f-9607-7b546023b433
 albumMBID: 1aa41b19-5a72-341b-bd91-4cf61d1dab6b
 artistLink: https://pixies.kontraband.store/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20170607-reviews-alt-j-relaxer.md
+++ b/data/posts/20170607-reviews-alt-j-relaxer.md
@@ -34,6 +34,7 @@ blurb: Relaxer falls together for spells, sometimes very well, but for the most 
 artistMBID: fc7bbf00-fbaa-4736-986b-b3ac0266ca9b
 albumMBID: 8a103b36-a632-425f-8980-da934b0c1eb3
 artistLink: https://store.altjband.com
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170614-reviews-oasis-definitely-maybe.md
+++ b/data/posts/20170614-reviews-oasis-definitely-maybe.md
@@ -35,6 +35,7 @@ blurb: Rock and roll delivered with swagger is such a buzz, and that’s the gam
 artistMBID: 39ab1aed-75e0-4140-bd47-540276886b60
 albumMBID: 451dca98-c118-32e1-9244-c47ca9c3c0f9
 artistLink: https://shop.oasisinet.com/
+reviewType: retrospective
 
 ---
 author: andre-dack

--- a/data/posts/20170621-reviews-royal-blood-how-did-we-get-so-dark.md
+++ b/data/posts/20170621-reviews-royal-blood-how-did-we-get-so-dark.md
@@ -34,6 +34,7 @@ blurb: There isn't much substance here. The album gives a far clearer impression
 artistMBID: aa62b28e-b6d4-4086-91d4-e5fac1ed56f3
 albumMBID: 64653649-ff78-4bc6-a9c2-eef09a21613d
 artistLink: https://store.royalbloodband.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170628-reviews-vince-staples-big-fish-theory.md
+++ b/data/posts/20170628-reviews-vince-staples-big-fish-theory.md
@@ -35,6 +35,7 @@ blurb: American hip-hop melded with house, techno, trap, and UK garage is an int
 artistMBID: 78e854b8-9713-4ff2-9218-6b3784893bff
 albumMBID: 847a8456-f742-4894-8fdb-5911afc65e9c
 artistLink: https://shop.thevincestaplesshow.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170705-reviews-the-prodigy-the-fat-of-the-land.md
+++ b/data/posts/20170705-reviews-the-prodigy-the-fat-of-the-land.md
@@ -34,6 +34,7 @@ blurb: "What The Fat of the Land lacks in diversity, it makes up for in consiste
 artistMBID: 4a4ee089-93b1-4470-af9a-6ff575d32704
 albumMBID: ac9138ce-6331-3f8d-86d7-69f13e4ab4f4
 artistLink: https://theprodigy.tmstor.es
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20170712-reviews-haim-something-to-tell-you.md
+++ b/data/posts/20170712-reviews-haim-something-to-tell-you.md
@@ -35,6 +35,7 @@ blurb: An album of inoffensive and enjoyable pop music. With strong instrumental
 artistMBID: aef06569-098f-4218-a577-b413944d9493
 albumMBID: 6e666e4f-5f7e-42cb-8989-c7b9aa12f470
 artistLink: https://shop.haimtheband.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170719-reviews-elvis-costello-my-aim-is-true.md
+++ b/data/posts/20170719-reviews-elvis-costello-my-aim-is-true.md
@@ -33,6 +33,7 @@ blurb: There is a remarkable confidence to the record that you wouldn’t usuall
 artistMBID: 8a338e06-d182-46f2-bd16-30a09bc840ba
 albumMBID: c7a4740f-2729-3895-8498-08c521886a95
 artistLink: https://store.elviscostello.com
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20170726-reviews-tyler-the-creator-flower-boy.md
+++ b/data/posts/20170726-reviews-tyler-the-creator-flower-boy.md
@@ -33,6 +33,7 @@ blurb: The album’s craft is a pleasure to experience, luring one's attention r
 artistMBID: f6beac20-5dfe-4d1f-ae02-0b0a740aafd6
 albumMBID: e248e931-c26c-4c94-aba2-2f89ce583901
 artistLink: https://golfwang.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170802-reviews-arcade-fire-everything-now.md
+++ b/data/posts/20170802-reviews-arcade-fire-everything-now.md
@@ -32,6 +32,7 @@ blurb: It’s hard to believe everyone involved in Everything Now was on the sam
 artistMBID: 52074ba6-e495-4ef3-9bb4-0703888a9f68
 albumMBID: 7a2b865d-0e23-45de-bf08-f0fcbd364883
 artistLink: https://www.arcadefirestore.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170809-reviews-michael-jackson-bad.md
+++ b/data/posts/20170809-reviews-michael-jackson-bad.md
@@ -32,6 +32,7 @@ blurb: It took Michael Jackson five years to follow up the greatest selling albu
 artistMBID: f27ec8db-af05-4f36-916e-3d57f91ecf5e
 albumMBID: a5711a77-42d1-3f4c-830c-e27a96f0800f
 artistLink: https://michaeljackson.com
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20170816-reviews-godspeed-you-black-emperor-f-sharp-a-sharp-infinity.md
+++ b/data/posts/20170816-reviews-godspeed-you-black-emperor-f-sharp-a-sharp-infinity.md
@@ -32,6 +32,7 @@ blurb: Almost fully instrumental, the post-rock arrangements twang and moan thro
 artistMBID: 3648db01-b29d-4ab9-835c-83f6a5068fe4
 albumMBID: 01d06c6e-a4e6-3d8b-8a45-42a598fe87d7
 artistLink: http://cstrecords.com/artist/godspeed-you-black-emperor/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20170823-reviews-grizzly-bear-painted-ruins.md
+++ b/data/posts/20170823-reviews-grizzly-bear-painted-ruins.md
@@ -32,6 +32,7 @@ blurb: There are moments of glory all over the release but they don't hang aroun
 artistMBID: 59a7fbcb-ff74-494d-abd0-9c82359040c9
 albumMBID: 3c04d855-7213-48e6-bead-f617c779f0d0
 artistLink: https://store.grizzly-bear.net
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170830-reviews-queens-of-the-stone-age-villains.md
+++ b/data/posts/20170830-reviews-queens-of-the-stone-age-villains.md
@@ -34,6 +34,7 @@ blurb: Mark Ronson’s production is pristine, which while technically impressiv
 artistMBID: 7dc8f5bd-9d0b-4087-9f73-dc164950bbd8
 albumMBID: 7e7270ae-a73a-48e2-a8a6-20e1112e21f8
 artistLink: https://store.qotsa.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170906-reviews-mogwai-every-countrys-sun.md
+++ b/data/posts/20170906-reviews-mogwai-every-countrys-sun.md
@@ -34,6 +34,7 @@ blurb: As is probably appropriate, Every Country’s Sun listens like an immense
 artistMBID: d700b3f5-45af-4d02-95ed-57d301bda93e
 albumMBID: a7342e9f-d2df-43ac-9c44-7a40f9c4cf98
 artistLink: https://store.mogwai.scot/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170913-reviews-deerhoof-mountain-moves.md
+++ b/data/posts/20170913-reviews-deerhoof-mountain-moves.md
@@ -34,6 +34,7 @@ blurb: Deerhoof cram dozens of ideas into a 40-minute album, which is not only t
 artistMBID: 11eabe0c-2638-4808-92f9-1dbd9c453429
 albumMBID: 2c88b473-3866-463c-912b-96b02a09cbc2
 artistLink: https://deerhoof.net/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20170922-reviews-the-verve-urban-hymns.md
+++ b/data/posts/20170922-reviews-the-verve-urban-hymns.md
@@ -36,6 +36,8 @@ blurb: An overwhelming, but vastly enjoyable experience — the essential Verve 
 artistMBID: d4d17620-fd97-4574-92a8-a2cb7e72ce42
 albumMBID: 3dd0c8e4-af53-3605-9c20-f27c7635fb60
 artistLink: https://www.merchbar.com/rock-alternative/verve
+reviewType: retrospective
+
 ---
 
 author: andre-dack

--- a/data/posts/20170927-reviews-godspeed-you-black-emperor-luciferian-towers.md
+++ b/data/posts/20170927-reviews-godspeed-you-black-emperor-luciferian-towers.md
@@ -31,6 +31,7 @@ blurb: Luciferian Towers’ rolls through sonic aesthetics lifted from Scottish 
 artistMBID: 3648db01-b29d-4ab9-835c-83f6a5068fe4
 albumMBID: bd835044-cd62-4f30-8447-438232763075
 artistLink: http://cstrecords.com/artist/godspeed-you-black-emperor/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20171004-reviews-wolf-alice-visions-of-a-life.md
+++ b/data/posts/20171004-reviews-wolf-alice-visions-of-a-life.md
@@ -41,6 +41,7 @@ blurb: Visions of a Life is a triumph of contemporary British rock. The riffs ro
 artistMBID: 3547f34a-db02-4ab7-b4a0-380e1ef951a9
 albumMBID: 7f231c61-20b2-49d6-ac66-1cacc4cc775f
 artistLink: https://store.wolfalice.co.uk/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20171011-reviews-marilyn-manson-heaven-upside-down.md
+++ b/data/posts/20171011-reviews-marilyn-manson-heaven-upside-down.md
@@ -33,6 +33,7 @@ blurb: You should come out of a Marilyn Manson record wanting your stomach pumpe
 artistMBID: 5dfdca28-9ddc-4853-933c-8bc97d87beec
 albumMBID: 7000fa0a-81eb-4238-af55-916e774b03a2
 artistLink: https://www.marilynmanson.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20171019-reviews-st-vincent-masseduction.md
+++ b/data/posts/20171019-reviews-st-vincent-masseduction.md
@@ -39,6 +39,7 @@ blurb: An ambitious, splintered record. Glammy schizoid pop rubs shoulders with 
 artistMBID: 5334edc0-5faf-4ca5-b1df-000de3e1f752
 albumMBID: 53dd291e-372f-4f76-844b-1b5b42df6832
 artistLink: https://store.ilovestvincent.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20171025-reviews-queen-news-of-the-world.md
+++ b/data/posts/20171025-reviews-queen-news-of-the-world.md
@@ -36,6 +36,7 @@ blurb: You’d expect huge, theatrical arrangements topped with sizzling guitar 
 artistMBID: 0383dadf-2a4e-4d10-a46a-e9e041da8eb3
 albumMBID: c172ea98-3a82-3254-b8ad-25a4f465ba03
 artistLink: https://www.queenonlinestore.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20171101-reviews-ramones-rocket-to-russia.md
+++ b/data/posts/20171101-reviews-ramones-rocket-to-russia.md
@@ -31,6 +31,7 @@ blurb: There’s a mindlessness to the instrumentation, lyricism, and vocals tha
 artistMBID: d6ed7887-a401-47a8-893c-34b967444d26
 albumMBID: 7de1e321-4a53-3feb-b83e-f1dab88bf952
 artistLink: https://www.merchbar.com/rock-alternative/ramones
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20171108-reviews-bob-dylan-highway-61-revisited.md
+++ b/data/posts/20171108-reviews-bob-dylan-highway-61-revisited.md
@@ -34,6 +34,7 @@ blurb: Dylan sings and we listen, the instrumentation hanging on his every word 
 artistMBID: 72c536dc-7137-4477-a521-567eeb840fa8
 albumMBID: fb48b1dc-412f-36aa-8820-1023c08c46c6
 artistLink: https://bobdylanstore.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20171116-reviews-lcd-soundsystem-sound-of-silver.md
+++ b/data/posts/20171116-reviews-lcd-soundsystem-sound-of-silver.md
@@ -35,6 +35,7 @@ blurb: Murphy's not merely indulging his influences or recreating the past here.
 artistMBID: 2aaf7396-6ab8-40f3-9776-a41c42c8e26b
 albumMBID: 5cbcdd9f-4b7d-3b3c-b9f2-6b0e75971157
 artistLink: https://kf-merch.com/collections/lcd-soundsystem
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20171122-reviews-baths-romaplasm.md
+++ b/data/posts/20171122-reviews-baths-romaplasm.md
@@ -31,6 +31,7 @@ blurb: The delicate craft of Wiesenfeld’s earlier work is mostly gone, and the
 artistMBID: 84a5c934-8318-4080-8606-32b80e1b054a
 albumMBID: e78ed940-4584-4988-b5a0-be22f2fd0c20
 artistLink: https://thehyv.shop/collections/baths/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20171129-reviews-bjork-utopia.md
+++ b/data/posts/20171129-reviews-bjork-utopia.md
@@ -34,6 +34,7 @@ blurb: The record is scattered with gorgeous moments that ultimately feel like a
 artistMBID: 87c5dedd-371d-4a53-9f7f-80522fb7f3cb
 albumMBID: c137e1f0-00bf-4bee-8d69-631664b52d1f
 artistLink: https://shop.bjork.com/
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20180110-reviews-eminem-the-marshall-mathers-lp.md
+++ b/data/posts/20180110-reviews-eminem-the-marshall-mathers-lp.md
@@ -32,6 +32,7 @@ blurb: The Marshall Mathers LP is Eminem’s finest accomplishment, but it’s t
 artistMBID: b95ce3ff-3d05-4e87-9e01-c97b66af13d4
 albumMBID: b0fa91c8-0996-38f1-ab84-797f58d7c4eb
 artistLink: https://shop.eminem.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20180117-reviews-led-zeppelin-led-zeppelin.md
+++ b/data/posts/20180117-reviews-led-zeppelin-led-zeppelin.md
@@ -33,6 +33,7 @@ blurb: Tapping into the bohemian sensibilities of the era, Led Zeppelin feel lik
 artistMBID: 678d88b2-87b0-403b-b63d-5da7465aecc3
 albumMBID: 0f18ec88-aa87-38a9-8a65-f03d81763560
 artistLink: https://store.ledzeppelin.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20180124-reviews-first-aid-kit-ruins.md
+++ b/data/posts/20180124-reviews-first-aid-kit-ruins.md
@@ -32,6 +32,7 @@ blurb: Artists can and should explore different plains, but Ruins sounds safe ra
 artistMBID: 373faa02-74d7-4b1d-9b47-7574ad510f8d
 albumMBID: 2db65b00-baa9-454d-b4a5-9f9e6f239cd1
 artistLink: https://shop.firstaidkitband.com
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180201-reviews-ty-segall-freedoms-goblin.md
+++ b/data/posts/20180201-reviews-ty-segall-freedoms-goblin.md
@@ -35,6 +35,7 @@ blurb: Freedom’s Goblin is a victim of its own ambition, and of Segall’s pro
 artistMBID: 07a17571-81fc-4cf8-a634-98f0d926d313
 albumMBID: b413f67f-a68b-48d7-8b33-abbc09e9f763
 artistLink: https://ty-segall.com/collections/all
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180208-reviews-the-fall-this-nations-saving-grace.md
+++ b/data/posts/20180208-reviews-the-fall-this-nations-saving-grace.md
@@ -36,6 +36,7 @@ blurb: There’s a lot to be said for the album’s quirks, but when all is said
 artistMBID: d5da1841-9bc8-4813-9f89-11098090148e
 albumMBID: e163ed54-842b-3114-9e98-a2d376029abd
 artistLink: https://thefall.xyz/emporium
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20180214-reviews-mgmt-little-dark-age.md
+++ b/data/posts/20180214-reviews-mgmt-little-dark-age.md
@@ -34,6 +34,7 @@ blurb: MGMT plod along with all the charisma of a mumbler with a weak chin, and 
 artistMBID: c485632c-b784-4ee9-8ea1-c5fb365681fc
 albumMBID: ff9b0645-2327-46f4-b2b4-a7f41946d39e
 artistLink: https://kf-merch.com/collections/mgmt
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180222-reviews-aphex-twin-richard-d-james-album.md
+++ b/data/posts/20180222-reviews-aphex-twin-richard-d-james-album.md
@@ -35,6 +35,7 @@ blurb: This is a compact, highly rewarding record; 30 minutes of mesmerising ele
 artistMBID: f22942a1-6f70-4f48-866e-238cb2308fbd
 albumMBID: 84d79dbe-7ac1-3ebc-9b36-238ddfb8229c
 artistLink: https://aphextwin.warp.net/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20180301-reviews-miles-davis-kind-of-blue.md
+++ b/data/posts/20180301-reviews-miles-davis-kind-of-blue.md
@@ -34,6 +34,7 @@ blurb: Each player is a master of their craft, yet not one of them flaunts their
 artistMBID: 561d854a-6a28-4aa7-8c99-323e6ce46c2a
 albumMBID: 8e8a594f-2175-38c7-a871-abb68ec363e7
 artistLink: https://www.milesdavisstore.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20180307-reviews-marmozets-knowing-what-you-know-now.md
+++ b/data/posts/20180307-reviews-marmozets-knowing-what-you-know-now.md
@@ -34,6 +34,7 @@ blurb: While the riffs and breakdowns are charging, raucous, and spine-tingling,
 artistMBID: a8397de0-fe98-42db-bf19-c26b99ead138
 albumMBID: 05bd1e3b-f355-4c1c-af93-c9e84f50f1f7
 artistLink: https://www.marmozets.co.uk
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180314-reviews-david-byrne-american-utopia.md
+++ b/data/posts/20180314-reviews-david-byrne-american-utopia.md
@@ -36,6 +36,7 @@ blurb: The record isn’t a masterclass, but there are still enough dashes of ge
 artistMBID: d4659efb-b8eb-4f03-95e9-f69ce35967a9
 albumMBID: 3e7a3cd4-fb2c-40e8-b093-eaffe8c9cfdd
 artistLink: https://davidbyrne.com/shop
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180321-reviews-yo-la-tengo-theres-a-riot-going-on.md
+++ b/data/posts/20180321-reviews-yo-la-tengo-theres-a-riot-going-on.md
@@ -32,6 +32,7 @@ blurb: Neither immersive nor memorable. Any time the group stumbles onto a passa
 artistMBID: 3f542031-b054-454d-b57b-812fa2a81b11
 albumMBID: 91517369-8453-4727-899e-e0b0abacf624
 artistLink: https://yolatengo.com/forsale/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180328-reviews-jack-white-boarding-house-reach.md
+++ b/data/posts/20180328-reviews-jack-white-boarding-house-reach.md
@@ -32,6 +32,7 @@ blurb: Those looking for the muscle of The White Stripes should just listen to T
 artistMBID: 3ae2fb37-8a23-429d-9920-bac811c4fc22
 albumMBID: e084177d-10ad-4b06-af26-c0586272150a
 artistLink: https://thirdmanstore.com/bands/jack-white
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180401-reviews-kirk-van-houten-can-i-borrow-a-feeling.md
+++ b/data/posts/20180401-reviews-kirk-van-houten-can-i-borrow-a-feeling.md
@@ -29,8 +29,10 @@ pullquote: Profoundly personal
 summary: Van Houten’s first and only studio album is flawed, for sure, but it’s also profoundly personal. The songwriting is ordinary, the production is rather unpleasant, yet there’s a certain charm to the whole affair. After 20+ years of mockery, I feel the album’s reputation is a little unwarranted.
 week: 139
 blurb: Van Houten’s first and only studio album is flawed, for sure, but also profoundly personal. After 20+ years of mockery its reputation seems a tad unwarranted.
-artistMBID: 
+artistMBID:
 albumMBID:
+reviewType: gag
+
 ---
 author: andre-dack
 

--- a/data/posts/20180404-reviews-air-moon-safari.md
+++ b/data/posts/20180404-reviews-air-moon-safari.md
@@ -33,6 +33,7 @@ blurb: Air combined chillout aesthetic with downtempo percussion, adding the pop
 artistMBID: cb67438a-7f50-4f2b-a6f1-2bb2729fd538
 albumMBID: b0bf2b77-b8cf-32f6-8893-9741d757b400
 artistLink: https://itunes.apple.com/artist/id5641488
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20180412-reviews-eels-the-deconstruction.md
+++ b/data/posts/20180412-reviews-eels-the-deconstruction.md
@@ -31,6 +31,7 @@ blurb: Mr. E’s found fresh form. Only he could write something like “Sweet S
 artistMBID: 14387b0f-765c-4852-852f-135335790466
 albumMBID: 99230c20-a341-4218-9c15-f498cdc4ed21
 artistLink: https://eelstheband.com/stores.php
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180418-reviews-boards-of-canada-music-has-the-right-to-children.md
+++ b/data/posts/20180418-reviews-boards-of-canada-music-has-the-right-to-children.md
@@ -34,6 +34,7 @@ blurb: The album is constantly evolving. The rare moments of tranquility take yo
 artistMBID: 69158f97-4c07-4c4e-baf8-4e4ab1ed666e
 albumMBID: 17d74d52-c92b-3b8d-9f87-218ab2d1c4a0
 artistLink: https://bleep.com/artist/78-boards-of-canada
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20180425-reviews-blur-modern-life-is-rubbish.md
+++ b/data/posts/20180425-reviews-blur-modern-life-is-rubbish.md
@@ -40,6 +40,7 @@ blurb: Inconsistent, but there's a lot to dig. The songwriting is hard to knock,
 artistMBID: ba853904-ae25-4ebb-89d6-c44cfbd71bd2
 albumMBID: e7affd78-d157-4772-a468-675fa4309c61
 artistLink: https://shop.blur.co.uk/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20180502-reviews-janelle-monae-dirty-computer.md
+++ b/data/posts/20180502-reviews-janelle-monae-dirty-computer.md
@@ -35,6 +35,7 @@ blurb: As enjoyable, sometimes euphoric, as Dirty Computer is, it’s far from p
 artistMBID: ee190f6b-7d98-43ec-b924-da5f8018eca0
 albumMBID: c3b6435c-2698-4909-9879-d80439e180fe
 artistLink: https://store.warnermusic.com/atlantic-records/artists/janelle-monae.html
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180509-reviews-jon-hopkins-singularity.md
+++ b/data/posts/20180509-reviews-jon-hopkins-singularity.md
@@ -33,6 +33,7 @@ blurb: Singularity is ultimately a record to admire rather than cherish, but the
 artistMBID: 0b0c25f4-f31c-46a5-a4fb-ccbf53d663bd
 albumMBID: 7b49f37f-06a6-4c71-970f-c1905c19906f
 artistLink: https://jonhopkins.shop.redstarmerch.com/store
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180517-reviews-arctic-monkeys-tranquility-base-hotel-and-casino.md
+++ b/data/posts/20180517-reviews-arctic-monkeys-tranquility-base-hotel-and-casino.md
@@ -37,6 +37,7 @@ blurb: Hushed, husky Turner monologues drift over sophisticated arrangements wit
 artistMBID: ada7a83c-e3e1-40f1-93f9-3e73dbc9298a
 albumMBID: 97ee3a0f-183b-4830-aa5c-45507a084d37
 artistLink: https://arcticmonkeys-store.com
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20180523-reviews-courtney-barnett-tell-me-how-you-really-feel.md
+++ b/data/posts/20180523-reviews-courtney-barnett-tell-me-how-you-really-feel.md
@@ -32,6 +32,7 @@ blurb: There's nothing mind-blowing here and no pretence that there should be. A
 artistMBID: 55111838-f001-494a-a1b5-9d818db85810
 albumMBID: b061cb70-1d31-4d5f-91cb-378c3a22f9dd
 artistLink: https://courtneybarnett.bandcamp.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180530-reviews-bruce-springsteen-darkness-on-the-edge-of-town.md
+++ b/data/posts/20180530-reviews-bruce-springsteen-darkness-on-the-edge-of-town.md
@@ -35,6 +35,7 @@ blurb: There’s no pretence. Here stands an honest-to-god ‘Murican wailing ab
 artistMBID: 70248960-cb53-4ea4-943a-edb18f7d336f
 albumMBID: b613123b-a234-3f48-9c45-e05bf4e6b9e7
 artistLink: https://brucespringsteenstore.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20180606-reviews-oneohtrix-point-never-age-of.md
+++ b/data/posts/20180606-reviews-oneohtrix-point-never-age-of.md
@@ -33,6 +33,7 @@ blurb: Nothing feels heavy-handed or crass. OPN purposefully avoids the tired tr
 artistMBID: 9cea062d-d476-447f-98b4-e67e14bfd1e4
 albumMBID: a7165142-0c5d-4859-825e-7858a22e2dd2
 artistLink: https://kontraband.shop/collections/point-never
+reviewType: newrelease
 
 ---
 

--- a/data/posts/20180614-reviews-pulp-different-class.md
+++ b/data/posts/20180614-reviews-pulp-different-class.md
@@ -39,6 +39,7 @@ blurb: Pulp nail the pop/rock formula to near perfection. The themes aren’t ne
 artistMBID: 76b2e842-5e85-4c97-ab62-d5bc315595b5
 albumMBID: 88f69eab-8f07-343b-847c-b944ad33dfcf
 artistLink: https://www.merchbar.com/rock-alternative/pulp
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20180621-reviews-sophie-oil-of-every-pearls-uninsides.md
+++ b/data/posts/20180621-reviews-sophie-oil-of-every-pearls-uninsides.md
@@ -35,6 +35,7 @@ blurb: Production is where SOPHIE shines. Whilst there is a plethora of interest
 artistMBID: 774b02d7-5056-4b0f-9d69-a82b6ae27cde
 albumMBID: e11aa3a6-9820-483c-98f8-603b5823178b
 artistLink: https://www.musicglue.com/sophie-shop/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180628-reviews-nine-inch-nails-bad-witch.md
+++ b/data/posts/20180628-reviews-nine-inch-nails-bad-witch.md
@@ -35,6 +35,7 @@ blurb: This is most downright exciting NIN album in quite some time. This is a g
 artistMBID: b7ffd2af-418f-4be2-bdd1-22f8b48613da
 albumMBID: a63e5fa6-d6ad-47bd-986d-4a27b0c9de70
 artistLink: https://store.nin.com/
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20180705-reviews-beastie-boys-hello-nasty.md
+++ b/data/posts/20180705-reviews-beastie-boys-hello-nasty.md
@@ -33,6 +33,7 @@ blurb: Whether the Beasties are rapping or singing, an infectious adolescent vig
 artistMBID: 9beb62b2-88db-4cea-801e-162cd344ee53
 albumMBID: 96c996ab-2a78-3abd-8974-c96b5724ae28
 artistLink: https://shop.beastieboys.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20180712-reviews-bjork-debut.md
+++ b/data/posts/20180712-reviews-bjork-debut.md
@@ -35,6 +35,7 @@ blurb: Björk creates her own identity by combining contrasting into something e
 artistMBID: 87c5dedd-371d-4a53-9f7f-80522fb7f3cb
 albumMBID: 6891a28c-5865-36e2-9e5f-c9fac1d3595f
 artistLink: https://shop.bjork.com/
+reviewType: retrospective
 
 ---
 author: andre-dack

--- a/data/posts/20180719-reviews-deep-purple-shades-of-deep-purple.md
+++ b/data/posts/20180719-reviews-deep-purple-shades-of-deep-purple.md
@@ -36,6 +36,7 @@ blurb: The sonic scenery is colourful and smoky, and the band sound like they’
 artistMBID: 79491354-3d83-40e3-9d8e-7592d58d790a
 albumMBID: bdb083d6-be5e-32b3-97df-3d899a8ff858
 artistLink: https://deeppurple.com/collections
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20180726-reviews-the-internet-hive-mind.md
+++ b/data/posts/20180726-reviews-the-internet-hive-mind.md
@@ -33,6 +33,7 @@ blurb: The record stagnates into a smooth R&B mood, though admittedly a rather l
 artistMBID: 45804465-4271-4e6a-b881-ce668ef09530
 albumMBID: 57d84f17-7b18-4800-b7c2-15833b468637
 artistLink: https://shop.internet-band.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180802-reviews-unkle-psyence-fiction.md
+++ b/data/posts/20180802-reviews-unkle-psyence-fiction.md
@@ -37,6 +37,7 @@ blurb: Psyence Fiction attempts to be the sonic equivalent of the visual cinema 
 artistMBID: 6648391e-7890-4f6c-b939-976f215195d3
 albumMBID: 17027712-7707-3791-ab65-5320e5ebe501
 artistLink: https://store.unkle.info/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20180809-reviews-kate-bush-hounds-of-love.md
+++ b/data/posts/20180809-reviews-kate-bush-hounds-of-love.md
@@ -39,6 +39,7 @@ blurb: That Bush could create something so deliriously weird and wild yet also b
 artistMBID: 4b585938-f271-45e2-b19a-91c634b5e396
 albumMBID: 017f2a37-a78f-3578-9611-fa40408e5d90
 artistLink: http://www.katebush.com/shop
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20180816-reviews-nwa-straight-outta-compton.md
+++ b/data/posts/20180816-reviews-nwa-straight-outta-compton.md
@@ -37,7 +37,8 @@ week: 159
 blurb: It has its lulls, but when Straight Outta Compton blows hot it feels unstoppable. N.W.A modelled a spirit of expression impossible to ignore.
 artistMBID: 3a54bffa-2314-44a2-927b-60144119c780
 albumMBID: fed1608d-80b7-38d2-aeb8-c6357f0d4c23
-artistLink: https://shop.urbanlegends.com/collections/n-w-a 
+artistLink: https://shop.urbanlegends.com/collections/n-w-a
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20180823-reviews-oh-sees-smote-reverser.md
+++ b/data/posts/20180823-reviews-oh-sees-smote-reverser.md
@@ -33,6 +33,7 @@ blurb: From its ludicrous track names to its filter-free kitchen sink instrument
 artistMBID: 194272cc-dcc8-4640-a4a6-66da7d250d5c
 albumMBID: b2cb65f0-2e0f-47cb-aff7-0f6793990e45
 artistLink: https://www.castlefacerecords.com/collections/thee-oh-sees
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180830-reviews-foals-antidotes.md
+++ b/data/posts/20180830-reviews-foals-antidotes.md
@@ -33,6 +33,7 @@ blurb: Foals leaned into their restless, agitated, math-rock roots and carved ou
 artistMBID: 6a65d878-fcd0-42cf-aff9-ca1d636a8bcc
 albumMBID: b3354e1f-317e-3b64-88e1-d4dc54571a6d
 artistLink: https://shop.foals.co.uk/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20180906-reviews-idles-joy-as-an-act-of-resistance.md
+++ b/data/posts/20180906-reviews-idles-joy-as-an-act-of-resistance.md
@@ -33,6 +33,7 @@ blurb: Joy as an Act of Resistance is refreshingly sincere and positive in a tim
 artistMBID: be465d4f-c28d-4ba1-94ab-ebaada7db8af
 albumMBID: 45003bef-d379-441d-b246-358f0b78985c
 artistLink: https://www.idlesband.com/shop/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180913-reviews-spiritualized-and-nothing-hurt.md
+++ b/data/posts/20180913-reviews-spiritualized-and-nothing-hurt.md
@@ -35,6 +35,7 @@ blurb: This is the first Spiritualized album in six years, so it's bizarre to he
 artistMBID: 65041e06-83d2-4987-ae52-c17a915fc82a
 albumMBID: bd913f09-b4bd-4d2f-a5ad-2c2d01419e23
 artistLink: https://spiritualized.kontraband.store/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180920-reviews-low-double-negative.md
+++ b/data/posts/20180920-reviews-low-double-negative.md
@@ -36,6 +36,7 @@ blurb: A constant stream of static with blunt edges, and the glitches are rarely
 artistMBID: 42faad37-8aaa-42e4-a300-5a7dae79ed24
 albumMBID: d24e94ad-80e2-405d-b20a-8fd6927213dd
 artistLink: https://merch.ambientinks.com/collections/low
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20180927-reviews-beak-beak-three.md
+++ b/data/posts/20180927-reviews-beak-beak-three.md
@@ -34,7 +34,8 @@ week: 65
 blurb: Instrumentals strike upon funky-yet-claustrophobic grooves, awaiting Barrow’s vocals to emerge from the mire. It’s a weird but often wonderful formula.
 artistMBID: bda0beab-8c08-4a34-9af0-97a1b647ad9b
 albumMBID: ce6461b2-8393-422a-8caa-5515d02b3bf8
-artistLink: https://beak.bandcamp.com/ 
+artistLink: https://beak.bandcamp.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20181004-reviews-sonic-youth-daydream-nation.md
+++ b/data/posts/20181004-reviews-sonic-youth-daydream-nation.md
@@ -36,6 +36,7 @@ blurb: Noisy and arty, the album remains a kind of anti-epic; 70 minutes of expl
 artistMBID: 5cbef01b-cc35-4f52-af7b-d0df0c4f61b9
 albumMBID: 24769a99-8189-3d8c-947e-dbc8574dad5c
 artistLink: https://sonicyouth.kungfustore.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20181011-reviews-queens-of-the-stone-age-queens-of-the-stone-age.md
+++ b/data/posts/20181011-reviews-queens-of-the-stone-age-queens-of-the-stone-age.md
@@ -34,6 +34,7 @@ blurb: QOTSA’s debut serves as a glimpse into their career as princesses, befo
 artistMBID: 7dc8f5bd-9d0b-4087-9f73-dc164950bbd8
 albumMBID: 17ee0d7f-4a9d-317f-a0b0-8ca528a34b19
 artistLink: https://store.qotsa.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20181018-reviews-kurt-vile-bottle-it-in.md
+++ b/data/posts/20181018-reviews-kurt-vile-bottle-it-in.md
@@ -36,6 +36,7 @@ blurb: The whole record has an easiness of manner, content to be the sonic backd
 artistMBID: e07a111e-4e8a-4651-a849-01ac60551ab2
 albumMBID: 2497ecd5-22e0-495b-a35c-cd3079c5b4ff
 artistLink: https://matadorrecords.com/kurt_vile
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20181026-reviews-neneh-cherry-broken-politics.md
+++ b/data/posts/20181026-reviews-neneh-cherry-broken-politics.md
@@ -37,6 +37,7 @@ blurb: For every moment of serenity there's a feeling of incompleteness, and the
 artistMBID: 527c65d1-9fdb-4482-8796-dde2980bd63a
 albumMBID: 2fda0cd0-db31-4448-81f6-4979b5192077
 artistLink: https://nenehcherry.bandcamp.com/
+reviewType: newrelease
 
 ---
 

--- a/data/posts/20181101-reviews-robyn-honey.md
+++ b/data/posts/20181101-reviews-robyn-honey.md
@@ -35,6 +35,7 @@ blurb: Honey delights in a downtempo sensuality. It finds voice in not being lar
 artistMBID: 5a8e07d5-d932-4484-a7f7-e700793a9c94
 albumMBID: 6f46d5e4-1e46-4480-b120-d04b37145f7f
 artistLink: https://store.robyn.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20181108-reviews-vince-staples-fm.md
+++ b/data/posts/20181108-reviews-vince-staples-fm.md
@@ -33,6 +33,7 @@ blurb: An audacious project, FM! sounds like a cartoonish snippet of overblown C
 artistMBID: 78e854b8-9713-4ff2-9218-6b3784893bff
 albumMBID: b211b91a-a7ec-42f8-ae46-2618e774ab18
 artistLink: https://shop.thevincestaplesshow.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20181115-reviews-a-tribe-called-quest-midnight-marauders.md
+++ b/data/posts/20181115-reviews-a-tribe-called-quest-midnight-marauders.md
@@ -33,6 +33,7 @@ blurb: Midnight Marauders’ tracklist is an exhibition of seemingly boundless c
 artistMBID: 9689aa5a-4471-4fb4-9721-07cecda0fa9f
 albumMBID: b445860f-edd9-4160-841c-fccf5533ecbd
 artistLink: https://www.atcqshop.com
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20181122-reviews-system-of-a-down-toxicity.md
+++ b/data/posts/20181122-reviews-system-of-a-down-toxicity.md
@@ -33,6 +33,7 @@ blurb: It may not be the best in its class, but Toxicity still has a charm to i
 artistMBID: cc0b7089-c08d-4c10-b6b0-873582c17fd6
 albumMBID: f50fbcb4-bfcd-3784-b4c9-44f4793e66b2
 artistLink: https://store.systemofadown.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20190110-reviews-the-rolling-stones-let-it-bleed.md
+++ b/data/posts/20190110-reviews-the-rolling-stones-let-it-bleed.md
@@ -38,6 +38,7 @@ blurb: Blues, psychedelia, jazz, and gospel are all deeply ingrained in the musi
 artistMBID: b071f9fa-14b0-4217-8e97-eb41da73f598
 albumMBID: 784c0edd-0f37-33a2-9ca5-dff87b4f999c
 artistLink: https://therollingstonesshop.co.uk/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20190117-reviews-david-bowie-hunky-dory.md
+++ b/data/posts/20190117-reviews-david-bowie-hunky-dory.md
@@ -33,6 +33,8 @@ blurb: The songwriting is unbelievably good, to the point where it sounds effort
 artistMBID: 5441c29d-3602-4898-b1a1-b77fa23b8e50
 albumMBID: 743b0b2e-a23a-3182-950e-232f8cb0dfb7
 artistLink: https://store.davidbowie.com/
+reviewType: retrospective
+
 ---
 
 author: andre-dack

--- a/data/posts/20190124-reviews-james-blake-assume-form.md
+++ b/data/posts/20190124-reviews-james-blake-assume-form.md
@@ -35,6 +35,7 @@ blurb: Blake has always been hugely successful at setting a mood, but for the fi
 artistMBID: 8dc08b1f-e393-4f85-a5dd-300f7693a8b8
 albumMBID: 8fceea87-5273-408b-a2f3-723d9b64800a
 artistLink: https://shop.jamesblakemusic.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20190131-reviews-the-specials-the-specials.md
+++ b/data/posts/20190131-reviews-the-specials-the-specials.md
@@ -34,6 +34,7 @@ blurb: There is plenty of anger in the album, but it is used constructively. At 
 artistMBID: 07eb40a2-2914-439c-a01d-15a685b84ddf
 albumMBID: 9c02ca99-df9a-3e48-8b7a-fabb599d19a3
 artistLink: https://shop.thespecials.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20190207-reviews-the-roots-things-fall-apart.md
+++ b/data/posts/20190207-reviews-the-roots-things-fall-apart.md
@@ -33,6 +33,7 @@ blurb: "Things Fall Apart is a fluid, continuous listen: understated to the poin
 artistMBID: 80b3cf5e-18fe-4c59-98c7-e5bb87210710
 albumMBID: 8f341430-85b9-3a66-875f-ed1202868393
 artistLink: https://shop.urbanlegends.com/collections/the-roots
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20190213-reviews-health-vol-4-slaves-of-fear.md
+++ b/data/posts/20190213-reviews-health-vol-4-slaves-of-fear.md
@@ -32,6 +32,7 @@ blurb: HEALTH have continued their trend of making exhilarating music, but somet
 artistMBID: 6805e4d5-f550-40fe-b731-05dc8229e74b
 albumMBID: f3f9294f-bc21-4b25-b421-d2486d131f42
 artistLink: https://fashion.youwillloveeachother.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20190221-reviews-kanye-west-the-college-dropout.md
+++ b/data/posts/20190221-reviews-kanye-west-the-college-dropout.md
@@ -32,6 +32,7 @@ blurb: Turning its back not only on the college path, but tropes of gangster rap
 artistMBID: 164f0d73-1234-4e2c-8743-d77bf2191051
 albumMBID: 8a01217e-6947-3927-a39b-6691104694f1
 artistLink: https://shop.kanyewest.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20190228-reviews-julia-jacklin-crushing.md
+++ b/data/posts/20190228-reviews-julia-jacklin-crushing.md
@@ -32,6 +32,7 @@ blurb: In a time where singer-songwriters are ten a penny, Julia Jacklin has cre
 artistMBID: f95d0f4f-d344-4acd-bec8-cc512b40f629
 albumMBID: 09a69267-c46e-4d68-8381-27517bf3288a
 artistLink: https://juliajacklin.bandcamp.com/
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20190307-reviews-solange-when-i-get-home.md
+++ b/data/posts/20190307-reviews-solange-when-i-get-home.md
@@ -30,6 +30,7 @@ blurb: When I Get Home feels like neither a continuation nor progression from it
 artistMBID: 410e7fd3-b865-4fa0-bb18-1b7fd53382ca
 albumMBID: 3ec17787-1d35-4d05-ac06-5294c99a8d4e
 artistLink: https://solange.blackplanet.com/shop/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20190314-reviews-foals-everything-not-saved-will-be-lost-part-1.md
+++ b/data/posts/20190314-reviews-foals-everything-not-saved-will-be-lost-part-1.md
@@ -34,6 +34,7 @@ blurb: Foals’ experimentation with synths and funky instrumentals is bold, oft
 artistMBID: 6a65d878-fcd0-42cf-aff9-ca1d636a8bcc
 albumMBID: ebbf6f7c-a843-4de9-96b7-5081dce485c7
 artistLink: https://shop.foals.co.uk/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20190321-reviews-bat-for-lashes-two-suns.md
+++ b/data/posts/20190321-reviews-bat-for-lashes-two-suns.md
@@ -38,6 +38,7 @@ blurb: While much of the Two Sun's tracklist doesn't feel as though it explores 
 artistMBID: 10000730-525f-4ed5-aaa8-92888f060f5f
 albumMBID: d4952445-d143-35a1-8420-d73cc78c668f
 artistLink: https://www.batforlashes.com/shop
+reviewType: retrospective
 
 ---
 author: andre-dack

--- a/data/posts/20190327-reviews-apparat-lp5.md
+++ b/data/posts/20190327-reviews-apparat-lp5.md
@@ -33,6 +33,7 @@ blurb: LP5 seems comfortable not pushing any boundaries. Tracks unravel steadily
 artistMBID: dc3dbfc1-f1f1-49c6-9d7c-425fabf3ae12
 albumMBID: 193f5514-4fad-4f60-b54c-23565213baa2
 artistLink: https://www.merchbar.com/dance-electronic-edm/apparat
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20190403-reviews-drenge-strange-creatures.md
+++ b/data/posts/20190403-reviews-drenge-strange-creatures.md
@@ -33,6 +33,7 @@ blurb: A solid entry into the band's catalogue and certainly worth a listen. As 
 artistMBID: b7f40a7c-0b93-45ad-9ae3-3bf6e28e9dd4
 albumMBID: bc507359-dc61-49cb-9073-456ff9d5be8b
 artistLink: https://drenge.tmstor.es/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20190410-reviews-weyes-blood-titanic-rising.md
+++ b/data/posts/20190410-reviews-weyes-blood-titanic-rising.md
@@ -37,6 +37,7 @@ blurb: Despite its glistening arrangements and ethereal production, this is a ch
 artistMBID: 469d6414-1f06-43de-80d5-17762d4a356a
 albumMBID: b30447b9-8e32-4e98-a128-9c18d9378e8d
 artistLink: https://weyesblood.kungfustore.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20190417-reviews-anderson-paak-ventura.md
+++ b/data/posts/20190417-reviews-anderson-paak-ventura.md
@@ -34,6 +34,7 @@ blurb: Ventura is super consistent hip hop experience, but we can’t help but w
 artistMBID: d02dd67e-f655-4600-bc47-f789f59e7367
 albumMBID: 59732510-a2ad-447d-bd8b-9cbdfef39f88
 artistLink: https://shop.andersonpaak.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20190422-reviews-the-stone-roses-the-stone-roses.md
+++ b/data/posts/20190422-reviews-the-stone-roses-the-stone-roses.md
@@ -36,6 +36,7 @@ blurb: A broody, elegant, sometimes transcendent blend of rock and electronic mu
 artistMBID: b5fa29f1-6c22-4321-a488-b5f363b06b06
 albumMBID: 88b86fe0-26f5-3949-817a-8082145e704d
 artistLink: https://stonerosesstore.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20190501-reviews-nick-cave-and-the-bad-seeds-let-love-in.md
+++ b/data/posts/20190501-reviews-nick-cave-and-the-bad-seeds-let-love-in.md
@@ -32,6 +32,7 @@ blurb: The arrangements are expansive and diverse, with coarse guitars blending 
 artistMBID: 172e1f1a-504d-4488-b053-6344ba63e6d0
 albumMBID: f369d4bf-71f1-31f5-9e01-ffdbf15acdbe
 artistLink: https://store.nickcave.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20190508-reviews-vampire-weekend-father-of-the-bride.md
+++ b/data/posts/20190508-reviews-vampire-weekend-father-of-the-bride.md
@@ -35,6 +35,7 @@ blurb: Catchy and sterile. The majority of these songs wouldn't feel out of plac
 artistMBID: af37c51c-0790-4a29-b995-456f98a6b8c9
 albumMBID: 1e083685-2e58-40eb-81ef-4163c26e01d6
 artistLink: https://vampireweekend.frocksteady.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20190515-reviews-tim-hecker-anoyo.md
+++ b/data/posts/20190515-reviews-tim-hecker-anoyo.md
@@ -34,6 +34,7 @@ blurb: To get the most out of the record, listeners must embrace the obscurity a
 artistMBID: c7ee3bc9-780c-42c0-91e9-4cd70ad692d3
 albumMBID: d5690b2d-334d-4156-849f-afb7d05903ff
 artistLink: https://tim-hecker-uk.myshopify.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20190522-reviews-tyler-the-creator-igor.md
+++ b/data/posts/20190522-reviews-tyler-the-creator-igor.md
@@ -34,6 +34,7 @@ blurb: Tyler plays against his strengths and manages to push himself to make a g
 artistMBID: f6beac20-5dfe-4d1f-ae02-0b0a740aafd6
 albumMBID: 0f1b9e07-b38b-4bba-9794-55e0924d7177
 artistLink: https://golfwang.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20190530-reviews-red-fang-murder-the-mountains.md
+++ b/data/posts/20190530-reviews-red-fang-murder-the-mountains.md
@@ -33,6 +33,7 @@ blurb: This album is a solid and grounded metal music offering with interesting 
 artistMBID: fb2cc158-0ad2-4dc5-a6b6-b2a1a8e2fe65
 albumMBID: 0e5b7ba3-2f3f-4405-b79a-9fa92478f83d
 artistLink: http://redfang.net/store.html
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20190606-reviews-denzel-curry-zuu.md
+++ b/data/posts/20190606-reviews-denzel-curry-zuu.md
@@ -30,6 +30,7 @@ blurb: The heated, high-tempered attitude that Curry carried on 2018's TA13OO ha
 artistMBID: 5f95440d-7737-4a36-9bcf-c05337f7129b
 albumMBID: 03961b3f-23aa-4331-91dc-5598a3f3b0e6
 artistLink: https://shop.ultimatedenzelcurry.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20190612-reviews-faith-no-more-the-real-thing.md
+++ b/data/posts/20190612-reviews-faith-no-more-the-real-thing.md
@@ -31,6 +31,7 @@ blurb: Faith No More create a journey of funky new wave rap-metal, and if that d
 artistMBID: b15ebd71-a252-417d-9e1c-3e6863da68f8
 albumMBID: 1ba7c980-4882-31fb-9918-12791f59d303
 artistLink: https://faithnomore.shopfirebrand.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20190622-reviews-baroness-gold-and-grey.md
+++ b/data/posts/20190622-reviews-baroness-gold-and-grey.md
@@ -30,6 +30,7 @@ blurb: Gold & Grey strives to be an epic of sorts, with its sprawling tracklist 
 artistMBID: eeb41a1e-4326-4d04-8c47-0f564ceecd68
 albumMBID: 95d5e345-5109-4fe9-9ba9-03a3898f0039
 artistLink: https://baronessmerch.shop.musictoday.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20190626-reviews-sigur-ros-agaetis-byrjun.md
+++ b/data/posts/20190626-reviews-sigur-ros-agaetis-byrjun.md
@@ -36,6 +36,7 @@ blurb: Layers upon layers of sensuous strings, steady soundscapes, and ghostly v
 artistMBID: f6f2326f-6b25-4170-b89d-e235b25508e8
 albumMBID: 62b427b8-1c52-34e7-b250-da2aa3e44860
 artistLink: https://sigurros.bandcamp.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20190703-reviews-thom-yorke-anima.md
+++ b/data/posts/20190703-reviews-thom-yorke-anima.md
@@ -34,6 +34,7 @@ blurb: ANIMA has the Yorke's classic oddball jumpiness, but there are some reall
 artistMBID: 8ed2e0b3-aa4c-4e13-bec3-dc7393ed4d6b
 albumMBID: 447435e2-8395-45f5-812b-f03f7525c8d6
 artistLink: https://store.wasteheadquarters.com/collections/thom-yorke-atoms-for-peace/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20190710-reviews-the-cure-disintegration.md
+++ b/data/posts/20190710-reviews-the-cure-disintegration.md
@@ -32,6 +32,7 @@ blurb: It’s like Frankenstein in a dinner jacket. Gothic synth rock sounds lik
 artistMBID: 69ee3720-a7cb-4402-b48d-a02c366f2bcf
 albumMBID: 494bf606-d2f7-36d0-8340-eadad8601d2b
 artistLink: https://store.universalmusic.com/thecure/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20190717-reviews-tycho-weather.md
+++ b/data/posts/20190717-reviews-tycho-weather.md
@@ -33,6 +33,7 @@ blurb: This is ambient Muzak. For all its smoothness and gentleness it barely le
 artistMBID: cbef45a9-7acb-4325-94c9-70081ac8d1b8
 albumMBID: 0ebe471f-87a1-4c60-af9d-135a4b080894
 artistLink: https://ukmerch.ambientinks.com/collections/tychoiso50
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20190731-reviews-elvis-presley-elvis-presley.md
+++ b/data/posts/20190731-reviews-elvis-presley-elvis-presley.md
@@ -34,6 +34,7 @@ blurb: A record can be iconic and flawed at the same time. Elvis' desbut is unre
 artistMBID: 01809552-4f87-45b0-afff-2c6f0730a3be
 albumMBID: 2ebeec96-6ef7-3d4d-943c-0b4a2af1d7cc
 artistLink: https://store.graceland.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20190810-reviews-chali-2na-krafty-kuts-adventures-of-a-reluctant-superhero.md
+++ b/data/posts/20190810-reviews-chali-2na-krafty-kuts-adventures-of-a-reluctant-superhero.md
@@ -35,6 +35,7 @@ artistMBID:
   - d14416ef-2283-49ef-9118-d690613d0bc9
 albumMBID: 5b058e40-25e4-4056-9123-e2315304791a
 artistLink: https://chali2nakraftykuts.bandcamp.com/
+reviewType: newRelease
 
 ---
 author: kieran-james

--- a/data/posts/20190821-reviews-blanck-mass-animated-violence-mild.md
+++ b/data/posts/20190821-reviews-blanck-mass-animated-violence-mild.md
@@ -38,6 +38,7 @@ blurb: It’s like Blanck Mass put Marilyn Manson, Nine Inch Nails, Mario, and t
 artistMBID: 0bbc4521-e5ac-4082-aa6c-fabfa606192d
 albumMBID: b10e623f-ef38-478f-902d-e4ee2eaf10dc
 artistLink: https://blanck-mass.tmstor.es/
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20190828-reviews-taylor-swift-lover.md
+++ b/data/posts/20190828-reviews-taylor-swift-lover.md
@@ -39,6 +39,7 @@ blurb: Lover isn’t as expansive as Kate Bush or as daring as St. Vincent, but 
 artistMBID: 20244d07-534f-4eff-b4d4-930878889970
 albumMBID: 30e9785b-7b50-4d29-b3d1-96fb55e3397f
 artistLink: https://store.taylorswift.com/
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20190904-reviews-tool-fear-inoculum.md
+++ b/data/posts/20190904-reviews-tool-fear-inoculum.md
@@ -32,6 +32,7 @@ blurb: While we can all appreciate a slow build, a rolling riff, and an expansiv
 artistMBID: 66fc5bf8-daa4-4241-b378-9bc9077939d2
 albumMBID: 76203bd0-466b-4802-a7ca-9b0097a3f862
 artistLink: https://store.toolband.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20190911-reviews-bat-for-lashes-lost-girls.md
+++ b/data/posts/20190911-reviews-bat-for-lashes-lost-girls.md
@@ -31,13 +31,14 @@ colours:
   - "#9b1713"
   - "#f8f0ee"
   - "#f8f0ee"
-pullquote: An '80s love letter
-summary: Ultimately, Lost Girls stands firm as a satisfying-yet-unspectacular entry in the Bat for Lashes discography. It's practically impossible not to recommend it to those who share Khan's affection for the '80s.
+pullquote: An ’80s love letter
+summary: Lost Girls stands firm as a satisfying-yet-unspectacular entry in the Bat for Lashes discography. It’s practically impossible not to recommend it to those who share Khan’s affection for the ’80s.
 week: 207
-blurb: A satisfying-yet-unspectacular entry in the Bat for Lashes discography. Heartily recommended to those who share Khan's affection for the '80s.
+blurb: A satisfying-yet-unspectacular entry in the Bat for Lashes discography. Heartily recommended to those who share Khan’s affection for the ’80s.
 artistMBID: 10000730-525f-4ed5-aaa8-92888f060f5f
 albumMBID: 7aadf038-4270-4e1f-820d-f9f367f6dfa9
 artistLink: https://www.batforlashes.com/shop
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20190918-reviews-jpegmafia-all-my-heroes-are-cornballs.md
+++ b/data/posts/20190918-reviews-jpegmafia-all-my-heroes-are-cornballs.md
@@ -33,6 +33,7 @@ blurb: There's a glaring sense of lunacy throughout. It's as though JPEGMAFIA is
 artistMBID: c42e60f4-4520-4954-b6e4-82bbdf532c11
 albumMBID: c35a4a3f-d584-42fc-ac0f-b9592aedd3b2
 artistLink: https://www.jpegmafia.net/store
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20190925-reviews-the-beatles-abbey-road.md
+++ b/data/posts/20190925-reviews-the-beatles-abbey-road.md
@@ -33,8 +33,10 @@ blurb: The last word of a band with nothing left to prove, and it sounds like it
 artistMBID: b10bbbfc-cf9e-42e0-be17-e2c3e1d2600d
 albumMBID: 9162580e-5df4-32de-80cc-f45a8d8a9b1d
 artistLink: https://www.thebeatles.com/store/
+reviewType: retrospective
 
 ---
+
 author: gabriel-sutton
 
 review: >-

--- a/data/posts/20191002-reviews-nine-inch-nails-pretty-hate-machine.md
+++ b/data/posts/20191002-reviews-nine-inch-nails-pretty-hate-machine.md
@@ -35,6 +35,7 @@ blurb: Nine Inch Nails rapidly became renowned for emotive and affecting music. 
 artistMBID: b7ffd2af-418f-4be2-bdd1-22f8b48613da
 albumMBID: fcb872a2-7ef9-3ed0-bd4a-7c55c78179b6
 artistLink: https://store.nin.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20191009-reviews-nick-cave-and-the-bad-seeds-ghosteen.md
+++ b/data/posts/20191009-reviews-nick-cave-and-the-bad-seeds-ghosteen.md
@@ -34,6 +34,7 @@ blurb: The aura of each composition is beautiful, yet there’s also the aching 
 artistMBID: 172e1f1a-504d-4488-b053-6344ba63e6d0
 albumMBID: 99fc75a4-3ff2-4248-9ae2-65d7026c7296
 artistLink: https://store.nickcave.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20191016-reviews-lightning-bolt-sonic-citadel.md
+++ b/data/posts/20191016-reviews-lightning-bolt-sonic-citadel.md
@@ -33,6 +33,7 @@ blurb: Sonic Citadel leans into the grubby, raw, jam-like nature of the duo’s 
 artistMBID: 978a36f7-85c6-44ca-a02e-7564e8fa8284
 albumMBID: e15e37de-2462-48fa-9f81-e512eb24fb12
 artistLink: https://lightningbolt.bandcamp.com/
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20191023-reviews-clipping-there-existed-an-addiction-to-blood.md
+++ b/data/posts/20191023-reviews-clipping-there-existed-an-addiction-to-blood.md
@@ -35,6 +35,7 @@ blurb: "The album is enthralling in the same way a vampire's glamouring might be
 artistMBID: 84ca8fa4-7cca-4948-a90a-cb44db29853d
 albumMBID: 16af6d23-9d40-49a6-952b-5631d4ec7981
 artistLink: http://www.clppng.com/merch
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20191030-reviews-desert-sessions-vols-11-and-12.md
+++ b/data/posts/20191030-reviews-desert-sessions-vols-11-and-12.md
@@ -35,8 +35,10 @@ blurb: The Desert Sessions project has always been a lot of fun. Returning from 
 artistMBID: 7a2e6b55-f149-4e74-be6a-30a1b1a387bb
 albumMBID: f95c7bc2-b502-4bd0-b24f-207c8c61fe19
 artistLink: https://store.qotsa.com/
+reviewType: newRelease
 
 ---
+
 author: andre-dack
 
 review: >-

--- a/data/posts/20191106-reviews-pj-harvey-let-england-shake.md
+++ b/data/posts/20191106-reviews-pj-harvey-let-england-shake.md
@@ -35,6 +35,7 @@ blurb: Quite simply one of the greatest anti-war albums of all time. In this cur
 artistMBID: e795e03d-b5d5-4a5f-834d-162cfb308a2c
 albumMBID: 9d504fde-1b02-4c14-b484-bcf94570153a
 artistLink: https://pjharvey.kontraband.store/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20191113-reviews-fka-twigs-magdalene.md
+++ b/data/posts/20191113-reviews-fka-twigs-magdalene.md
@@ -42,6 +42,7 @@ blurb: For all its instances of greatness and undeniable beauty, MAGDALENE gets 
 artistMBID: 1e4e9db7-5068-4a9c-bdd0-5777e47172c8
 albumMBID: 5d78819e-18b5-4d1a-a286-d816ce868044
 artistLink: https://shop.fkatwi.gs/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200115-reviews-black-sabbath-paranoid.md
+++ b/data/posts/20200115-reviews-black-sabbath-paranoid.md
@@ -35,6 +35,7 @@ blurb: As far as straight up heavy metal goes, Black Sabbath's Paranoid is one o
 artistMBID: 5182c1d9-c7d2-4dad-afa0-ccfeada921a8
 albumMBID: cc053745-c447-3566-8f27-bed5438c9133
 artistLink: https://blacksabbathapparelshop.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20200122-reviews-algiers-there-is-no-year.md
+++ b/data/posts/20200122-reviews-algiers-there-is-no-year.md
@@ -37,6 +37,7 @@ blurb: Throughout much of its run-time, There is No Year seems content revelling
 artistMBID: 258e8672-1db1-469a-a505-00a42aaf0973
 albumMBID: dcfb7546-d9b4-4e12-9ba2-95fda90a52d6
 artistLink: https://algierstheband.terriblemerch.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200205-reviews-squarepusher-be-up-a-hello.md
+++ b/data/posts/20200205-reviews-squarepusher-be-up-a-hello.md
@@ -34,6 +34,7 @@ blurb: This isn't a game changer; instead a proud statement, delivered with fine
 artistMBID: 4d86ad4e-28d8-4e9f-8cf4-735c57060fdc
 albumMBID: 6dc5a5e5-a07b-453e-8423-021dbe199253
 artistLink: https://squarepusher.net/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200212-reviews-joy-division-unknown-pleasures.md
+++ b/data/posts/20200212-reviews-joy-division-unknown-pleasures.md
@@ -35,6 +35,7 @@ blurb: Pretty much everything about Unknown Pleasures was, and continues to be, 
 artistMBID: 9a58fda3-f4ed-4080-a3a5-f457aac9fcdd
 albumMBID: 42352def-1aab-3000-b548-895ebd869cb6
 artistLink: https://store.neworder.com/joy-division.html/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20200219-reviews-tame-impala-the-slow-rush.md
+++ b/data/posts/20200219-reviews-tame-impala-the-slow-rush.md
@@ -35,6 +35,7 @@ blurb: Kevin Parker’s latest project has all the hallmarks of what came before
 artistMBID: 63aa26c3-d59b-4da4-84ac-716b54f1ef4d
 albumMBID: c6fc678e-e987-45c5-811c-e2bd09c8b902
 artistLink: https://shoptameimpala.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200226-reviews-pj-harvey-to-bring-you-my-love.md
+++ b/data/posts/20200226-reviews-pj-harvey-to-bring-you-my-love.md
@@ -43,6 +43,7 @@ blurb: With Harvey it feels like you’ve stumbled across the ad hoc performance
 artistMBID: e795e03d-b5d5-4a5f-834d-162cfb308a2c
 albumMBID: 2a976d93-1131-3821-9bcb-6c79542d93aa
 artistLink: https://pjharvey.kontraband.store/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20200304-reviews-gorillaz-plastic-beach.md
+++ b/data/posts/20200304-reviews-gorillaz-plastic-beach.md
@@ -37,6 +37,8 @@ blurb: Classic Gorillaz. Buoyant and aspirational, the project feels like a rele
 artistMBID: e21857d5-3256-4547-afb3-4b6ded592596
 albumMBID: 5a676824-18cd-4f7f-89f0-df21623e2042
 artistLink: https://store.gorillaz.com/
+reviewType: retrospective
+
 ---
 
 author: andre-dack

--- a/data/posts/20200318-reviews-jay-electronica-a-written-testimony.md
+++ b/data/posts/20200318-reviews-jay-electronica-a-written-testimony.md
@@ -34,7 +34,8 @@ week: 224
 blurb: A distinctive project that showcases exactly what Jay Electronica is all about. With a little help from a friend, of course.
 artistMBID: 8bf283b9-b1e2-4632-a953-eacd212a543e
 albumMBID: e3db4db7-603a-420b-8e7d-112bd4a8f6c9
-artistLink: https://awrittentestimony.com/ 
+artistLink: https://awrittentestimony.com/
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20200325-reviews-moaning-uneasy-laughter.md
+++ b/data/posts/20200325-reviews-moaning-uneasy-laughter.md
@@ -35,6 +35,7 @@ blurb: The album's all a bit clean cut, a perfectly pleasant smorgasbord of goth
 artistMBID: d5d4af51-8c20-45ed-9cc4-f8bbbb28289d
 albumMBID: 5be88c22-464f-4b6a-9f14-945c589a9840
 artistLink: https://moaning.bandcamp.com
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20200401-reviews-the-be-sharps-meet-the-be-sharps.md
+++ b/data/posts/20200401-reviews-the-be-sharps-meet-the-be-sharps.md
@@ -35,6 +35,8 @@ week: 226
 blurb: The richest and most melodious harmonisations of four men since John, Mark, Luke, and Matthew collaborated on their bestselling project 2,000 years ago.
 artistMBID: 
 albumMBID:
+reviewType: gag
+
 ---
 author: andre-dack
 

--- a/data/posts/20200403-reviews-waxahatchee-saint-cloud.md
+++ b/data/posts/20200403-reviews-waxahatchee-saint-cloud.md
@@ -33,6 +33,7 @@ blurb: Country music with a modern edge. To witness these songs being played liv
 artistMBID: 42321e24-42b6-4f08-b0d9-8325ee887a20
 albumMBID: 38b46e05-894f-432a-97cb-a3a1219c14bd
 artistLink: https://kf-merch.com/collections/waxahatchee
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200408-reviews-thundercat-it-is-what-it-is.md
+++ b/data/posts/20200408-reviews-thundercat-it-is-what-it-is.md
@@ -28,12 +28,13 @@ colours:
   - "#cc940d"
   - "#cc940d"
 pullquote: A vibe
-summary: Thundercat rides the album like a surfer hanging ten on the world’s smallest, smoothest, slowest wave. It’s drifting with style, a good time but not terribly eventful.
+summary: Thundercat rides the album like a surfer hanging ten on the world’s smallest, smoothest, slowest wave. It’s drifting with style; a good time but not terribly eventful.
 week: 228
 blurb: Thundercat rides the album like a surfer hanging ten on the world’s smallest, smoothest, slowest wave. It’s drifting with style, an uneventful good time.
 artistMBID: 044fd265-79dd-43eb-afc4-8b20becf7e17
 albumMBID: 9ffdc0f1-6683-44f1-9194-a247ecb9b297
 artistLink: https://thundercat.bandcamp.com/
+reviewType: newRelease
 
 ---
 
@@ -62,7 +63,7 @@ score:
 author: frederick-obrien
 
 review: >-
-  *It Is What It Is* is what it is. Thundercat rides the album like a surfer hanging ten on the world’s smallest, smoothest, slowest wave. It’s drifting with style, a good time but not terribly eventful. That will likely be enough for many listeners – and I certainly don’t begrudge the approach – it just seems a bit anticlimactic.
+  *It Is What It Is* is what it is. Thundercat rides the album like a surfer hanging ten on the world’s smallest, smoothest, slowest wave. It’s drifting with style; a good time but not terribly eventful. That will likely be enough for many listeners – and I certainly don’t begrudge the approach – it just seems a bit anticlimactic.
 
   You can tell on an intellectual level that the arrangements are sophisticated and sexy. The album knows its way around a bassline, and the harmonies are sunlit echoes. (Echoes.) I understand all that, and I hear it… I don’t necessarily feel it. The production is so polished and the grooves are so smooth you’d be forgiven for missing them entirely.
 

--- a/data/posts/20200415-reviews-laura-marling-song-for-our-daughter.md
+++ b/data/posts/20200415-reviews-laura-marling-song-for-our-daughter.md
@@ -36,6 +36,7 @@ blurb: Robed in ever so tasteful shades of pinkish beige, bluish beige, and beig
 artistMBID: cd9713d6-6e5f-4143-9412-4d12b7bd47f2
 albumMBID: 95335b28-967c-49a2-bbc1-952c9fd0fb58
 artistLink: https://store.lauramarling.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200422-reviews-eob-earth.md
+++ b/data/posts/20200422-reviews-eob-earth.md
@@ -35,6 +35,7 @@ blurb: Solo material from a band as prolific as Radiohead can go one of two ways
 artistMBID: 9ae93352-6da7-4efb-abb2-e43ef51acb25
 albumMBID: 43b0dee9-2952-41ad-a43a-d35d06900603
 artistLink: https://store.eobmusic.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200429-reviews-grandaddy-the-sophtware-slump.md
+++ b/data/posts/20200429-reviews-grandaddy-the-sophtware-slump.md
@@ -39,6 +39,7 @@ blurb: Despite extended musical passages and eccentric lyrics, The Sophtware Slu
 artistMBID: 9d4c4835-c71a-4647-a4fc-263e26832cd0
 albumMBID: 1feb6a47-2725-3f26-9762-3dc0ecffe4de
 artistLink: https://grandaddy-us.myshopify.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20200506-reviews-flying-lotus-cosmogramma.md
+++ b/data/posts/20200506-reviews-flying-lotus-cosmogramma.md
@@ -40,6 +40,7 @@ blurb: Cosmogramma is a stunning showcase of music made, or at the very least as
 artistMBID: fc7376fe-1a6f-4414-b4a7-83f50ed59c92
 albumMBID: ddae2c76-1433-4a9a-be05-3447bda75eee
 artistLink: https://www.merchbar.com/dance-electronic-edm/flying-lotus/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20200513-reviews-kraftwerk-the-man-machine.md
+++ b/data/posts/20200513-reviews-kraftwerk-the-man-machine.md
@@ -43,6 +43,7 @@ blurb: The album makes for hypnotic listening, bobbling along like a well-manner
 artistMBID: 5700dcd4-c139-4f31-aa3e-6382b9af9032
 albumMBID: 05f467f1-7524-4d9f-8794-81fbb3fef12f
 artistLink: https://www.merchbar.com/dance-electronic-edm/kraftwerk/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20200520-reviews-moses-sumney-grae.md
+++ b/data/posts/20200520-reviews-moses-sumney-grae.md
@@ -43,6 +43,7 @@ blurb: Emotionally vulnerable and creatively restless. The record plays out like
 artistMBID: 89c081d4-2ab2-4d3e-8589-ad77dfc40384
 albumMBID: 1c50740c-1acb-4bd8-bf54-fc6a6dc859cb
 artistLink: https://www.hellomerch.com/collections/moses-sumney/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200527-reviews-modest-mouse-the-moon-and-antarctica.md
+++ b/data/posts/20200527-reviews-modest-mouse-the-moon-and-antarctica.md
@@ -40,7 +40,8 @@ week: 235
 blurb: Provided you're in the right mood, The Moon & Antarctica is one of the standout indie rock releases of the 2000s.
 artistMBID: a96ac800-bfcb-412a-8a63-0a98df600700
 albumMBID: a8e26959-b3b2-3440-a74a-0dc06cd6310d
-artistLink: https://shop.glacialpace.com/ 
+artistLink: https://shop.glacialpace.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20200610-reviews-run-the-jewels-rtj4.md
+++ b/data/posts/20200610-reviews-run-the-jewels-rtj4.md
@@ -37,6 +37,7 @@ blurb: "El-P and Mike are on the frontline now. Here the duo stand up to be coun
 artistMBID: a80c5dc5-b12e-4667-9f5a-b568961f3839
 albumMBID: 46dc2b09-a6b1-4271-bf1d-01f3b3b95c23
 artistLink: https://rtj4.link/store/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200617-reviews-jehnny-beth-to-love-is-to-live.md
+++ b/data/posts/20200617-reviews-jehnny-beth-to-love-is-to-live.md
@@ -33,7 +33,8 @@ week: 237
 blurb: The album is purposefully provocative, and whilst this brings exhilarating and hard-hitting moments, it can also result in disorientating frenzies.
 artistMBID: fdac609a-63d0-49b9-823a-daec52a0db97
 albumMBID: b0f7e88f-81b4-431d-ad38-7a3ae524b424
-artistLink: https://shop.jehnnybeth.com/ 
+artistLink: https://shop.jehnnybeth.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200624-reviews-bob-dylan-rough-and-rowdy-ways.md
+++ b/data/posts/20200624-reviews-bob-dylan-rough-and-rowdy-ways.md
@@ -34,7 +34,8 @@ week: 238
 blurb: Grizzled and dusty, the album is as world-weary as it is worldly. Dylan sits in his chair by the fire and regales with stories, between naps.
 artistMBID: 72c536dc-7137-4477-a521-567eeb840fa8
 albumMBID: 43b12592-d808-44de-a5df-ebd7c6b2b75c
-artistLink: https://bobdylanstore.com/ 
+artistLink: https://bobdylanstore.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200701-reviews-khruangbin-mordechai.md
+++ b/data/posts/20200701-reviews-khruangbin-mordechai.md
@@ -38,6 +38,7 @@ blurb: Relaxing yet affecting, these songs are begging to be listened to with a 
 artistMBID: aea4c9b9-9f8d-49dc-b2ca-57d6f26e8634
 albumMBID: 53e6ec80-ddc7-4db8-80f8-5e081545c856
 artistLink: https://www.hellomerch.com/collections/khruangbin/ 
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200708-reviews-coldplay-parachutes.md
+++ b/data/posts/20200708-reviews-coldplay-parachutes.md
@@ -38,7 +38,8 @@ week: 240
 blurb: Parachutes is nice-feeling music written by nice-seeming blokes. As is the case with all things Coldplay, it’s easy to mock, but it’s easy to like as well.
 artistMBID: cc197bad-dc9c-440d-a5b5-d52ba2e14234
 albumMBID: 1dc4c347-a1db-32aa-b14f-bc9cc507b843
-artistLink: https://shop.coldplay.com/ 
+artistLink: https://shop.coldplay.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20200722-reviews-lianne-la-havas-lianne-la-havas.md
+++ b/data/posts/20200722-reviews-lianne-la-havas-lianne-la-havas.md
@@ -32,6 +32,7 @@ blurb: The record lacks hooks and memorable moments. Although this is La Havas' 
 artistMBID: 680466d6-f05b-44f6-858d-625d1b5087f6
 albumMBID: e58e9147-0d9b-4dab-95f2-ae134542ea26
 artistLink: https://www.liannelahavas.com/merch/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200805-reviews-neil-young-after-the-gold-rush.md
+++ b/data/posts/20200805-reviews-neil-young-after-the-gold-rush.md
@@ -39,6 +39,7 @@ blurb: Along with a supremely confident and symbiotic backing band, Neil Young i
 artistMBID: 75167b8b-44e4-407b-9d35-effe87b223cf
 albumMBID: b6a3952b-9977-351c-a80a-73e023143858
 artistLink: https://neilyoung.warnerrecords.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20200812-reviews-glass-animals-dreamland.md
+++ b/data/posts/20200812-reviews-glass-animals-dreamland.md
@@ -35,6 +35,7 @@ blurb: The album is a nostalgia trip and, unintentionally(?), the longest ‘onl
 artistMBID: 20395131-fbde-43ce-b141-b700cfdae99c
 albumMBID: 1ccd441a-a906-4773-8e72-e4055732a784
 artistLink: https://shop.glassanimals.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200819-reviews-dead-kennedys-fresh-fruit-for-rotting-vegetables.md
+++ b/data/posts/20200819-reviews-dead-kennedys-fresh-fruit-for-rotting-vegetables.md
@@ -37,6 +37,7 @@ blurb: Dead Kennedys' iconic debut still boasts some of the most brilliant and u
 artistMBID: 37c78aeb-d196-42b5-b991-6afb4fc9bc2e
 albumMBID: 3495fca0-ce60-3342-93f2-23fd525d8069
 artistLink: https://www.hellomerch.com/collections/dead-kennedys
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20200826-reviews-nas-kings-disease.md
+++ b/data/posts/20200826-reviews-nas-kings-disease.md
@@ -37,6 +37,7 @@ blurb: A pleasant, consistent, and enjoyable listen. Here’s hoping Nas and Hit
 artistMBID: cfbc0924-0035-4d6c-8197-f024653af823
 albumMBID: 73edf0fe-d715-44e9-b18d-c16a4a765140
 artistLink: https://shop.nasirjones.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200902-reviews-kelly-lee-owens-inner-song.md
+++ b/data/posts/20200902-reviews-kelly-lee-owens-inner-song.md
@@ -35,6 +35,7 @@ blurb: The album is so delicate that it feels too fragile for its own good. Itâ€
 artistMBID: 9d88eaab-f90a-4fbe-b84f-20da5518cd26
 albumMBID: 4f883542-76d0-4fb1-bd7f-f53ccd5e8bc3
 artistLink: https://kellyleeowens.bandcamp.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200909-reviews-all-them-witches-nothing-as-the-ideal.md
+++ b/data/posts/20200909-reviews-all-them-witches-nothing-as-the-ideal.md
@@ -40,6 +40,7 @@ blurb: A sumptuously produced blend of folk, post-rock, and psychedelia, all wit
 artistMBID: b574bfea-2359-4e9d-93f6-71c3c9a2a4f0
 albumMBID: 8188a5e9-c9b1-41ce-b8e4-602f3b7e1ea8
 artistLink: https://allthemwitches.bandcamp.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200916-reviews-doves-the-universal-want.md
+++ b/data/posts/20200916-reviews-doves-the-universal-want.md
@@ -38,6 +38,7 @@ blurb: It seems that a template was drawn up and filled in ten times over, such 
 artistMBID: 9de8f66e-3cd1-4f11-8328-38200f0612b0
 albumMBID: d47ed363-bf57-426d-b061-34675b8892b6
 artistLink: https://shop.dovesofficial.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20200930-reviews-idles-ultra-mono.md
+++ b/data/posts/20200930-reviews-idles-ultra-mono.md
@@ -36,6 +36,7 @@ blurb: There is a huge amount of musical and lyrical ingenuity to enjoy here, wi
 artistMBID: be465d4f-c28d-4ba1-94ab-ebaada7db8af
 albumMBID: baa817a4-1987-44b7-bd0e-1d5eba738619
 artistLink: https://www.idlesband.com/shop/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20201021-reviews-the-beach-boys-pet-sounds.md
+++ b/data/posts/20201021-reviews-the-beach-boys-pet-sounds.md
@@ -34,6 +34,7 @@ blurb: The harmonies are wonderful, the instrumentation is charming, and, well, 
 artistMBID: ebfc1398-8d96-47e3-82c3-f782abcdb13d
 albumMBID: fdd96703-7b21-365e-bdea-38029fbeb84e
 artistLink: https://shop.thebeachboys.com
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20201028-reviews-clipping-visions-of-bodies-being-burned.md
+++ b/data/posts/20201028-reviews-clipping-visions-of-bodies-being-burned.md
@@ -34,6 +34,7 @@ blurb: Relentless and unpredictable, the album's like the spawn of a Satanic rit
 artistMBID: 84ca8fa4-7cca-4948-a90a-cb44db29853d
 albumMBID: 8e5a1df1-2cb8-4a7e-985c-f78919c2c9b2
 artistLink: http://www.clppng.com/merch
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20201104-reviews-nothing-the-great-dismal.md
+++ b/data/posts/20201104-reviews-nothing-the-great-dismal.md
@@ -40,6 +40,7 @@ blurb: Unabashedly grim, but reassuringly gentle. The album's striking cover art
 artistMBID: e86b5e8c-8a11-40ea-9bb0-551df95e99d4
 albumMBID: 0e9eff21-8115-4ab3-877c-5c4f6d0e09a0
 artistLink: https://www.bandofnothing.com/shop
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20210113-reviews-mf-doom-mm-food.md
+++ b/data/posts/20210113-reviews-mf-doom-mm-food.md
@@ -34,6 +34,7 @@ blurb: Never does the record come off as grandiose or self-important; it’s jus
 artistMBID: 188711ed-c99b-439c-844a-ca831f63a727
 albumMBID: ec84ab32-eb41-3d91-a099-7a01c72f21d2
 artistLink: https://gasdrawls.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20210120-reviews-midnight-sister-painting-the-roses.md
+++ b/data/posts/20210120-reviews-midnight-sister-painting-the-roses.md
@@ -40,6 +40,7 @@ blurb: Part dramatic dream, part sun-soaked soliloquy, part love letter to mid-c
 artistMBID: d2523400-656e-4bd2-98c3-5582d2da3a3f
 albumMBID: b52cdcc6-bef1-413d-8a22-b809b0498310
 artistLink: https://midnightsister.bandcamp.com/merch
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20210127-reviews-bicep-isles.md
+++ b/data/posts/20210127-reviews-bicep-isles.md
@@ -38,6 +38,7 @@ blurb: Tracks swirl about at a slower pace than in Bicep’s debut. It often fee
 artistMBID: 10e8f0df-90f9-4957-aedd-c4e0d187e3a8
 albumMBID: fa402a46-b4b1-40d6-8d3b-b051550eb687
 artistLink: https://store.bicepmusic.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20210203-reviews-can-tago-mago.md
+++ b/data/posts/20210203-reviews-can-tago-mago.md
@@ -45,6 +45,7 @@ blurb: The record listens like an all-night jam at an impossibly cool bohemian g
 artistMBID: 13501c7d-d181-45ba-af52-5f101d8516a0
 albumMBID: 13d08c0e-14e2-30b2-9ad7-5f501761a8ea
 artistLink: https://www.spoonrecords.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20210210-reviews-black-country-new-road-for-the-first-time.md
+++ b/data/posts/20210210-reviews-black-country-new-road-for-the-first-time.md
@@ -43,6 +43,7 @@ blurb: A blend of teenage angst and a primordial, animalistic sense of something
 artistMBID: e9403d9c-329b-4108-a26f-564159d441d9
 albumMBID: 968b13bb-026b-410e-831e-a7bb7418ea60
 artistLink: https://blackcountrynewroad.bandcamp.com/merch
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20210217-reviews-django-django-glowing-in-the-dark.md
+++ b/data/posts/20210217-reviews-django-django-glowing-in-the-dark.md
@@ -40,6 +40,7 @@ blurb: The album dusky psychedelic pop is covered in so much haze that, despite 
 artistMBID: 4bfce038-b1a0-4bc4-abe1-b679ab900f03
 albumMBID: 590b2c0f-1a80-4e6f-9c7e-e5388620620b
 artistLink: https://shop.djangodjango.co.uk
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20210224-reviews-mogwai-as-the-love-continues.md
+++ b/data/posts/20210224-reviews-mogwai-as-the-love-continues.md
@@ -37,6 +37,7 @@ blurb: An expansive, impressive listen with delicious moments of climactic erupt
 artistMBID: d700b3f5-45af-4d02-95ed-57d301bda93e
 albumMBID: ef8e8e4d-05a2-4732-b68a-c5b6af86d786
 artistLink: https://store.mogwai.scot/
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20210303-reviews-julien-baker-little-oblivions.md
+++ b/data/posts/20210303-reviews-julien-baker-little-oblivions.md
@@ -35,6 +35,7 @@ blurb: The shift away from skeletal guitars is welcome, but Baker’s strength d
 artistMBID: e3bda984-f349-4924-b4b8-f72478bbb3f3
 albumMBID: 03e8da57-fd08-4864-89e7-4919ddfe4735
 artistLink: https://julienbaker.com/collections/music
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20210310-reviews-kings-of-leon-when-you-see-yourself.md
+++ b/data/posts/20210310-reviews-kings-of-leon-when-you-see-yourself.md
@@ -35,6 +35,7 @@ blurb: An album caught in no-man’s land, its dozy stadium rock tunes neither 
 artistMBID: 6ffb8ea9-2370-44d8-b678-e9237bbd347b
 albumMBID: 4486d356-5ad2-43ec-b9f0-c571eafde4f3
 artistLink: https://kingsofleonshop.com/
+reviewType: newRelease
 
 ---
 author: gabriel-sutton

--- a/data/posts/20210317-reviews-leonard-cohen-songs-of-love-and-hate.md
+++ b/data/posts/20210317-reviews-leonard-cohen-songs-of-love-and-hate.md
@@ -36,6 +36,7 @@ blurb: An epic poem in LP form, throughout Cohen embraces a brutal honesty that,
 artistMBID: 65314b12-0e08-43fa-ba33-baaa7b874c15
 albumMBID: 964ccc52-2873-3bce-a806-73d71532c539
 artistLink: https://www.leonardcohenshop.com/
+reviewType: retrospective
 
 ---
 author: andre-dack

--- a/data/posts/20210324-reviews-lana-del-rey-chemtrails-over-the-country-club.md
+++ b/data/posts/20210324-reviews-lana-del-rey-chemtrails-over-the-country-club.md
@@ -35,6 +35,7 @@ blurb: Vintage Del Rey (in both senses of the word), though the curious thing ab
 artistMBID: b7539c32-53e7-4908-bda3-81449c367da6
 albumMBID: b76289b0-605e-495e-b9f4-80437b70c94e
 artistLink: https://lanadelreystore.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20210401-reviews-bleeding-gums-murphy-sax-on-the-beach.md
+++ b/data/posts/20210401-reviews-bleeding-gums-murphy-sax-on-the-beach.md
@@ -35,6 +35,7 @@ blurb: From brotherly estrangement to Fabergéal financial ruin to dental calami
 artistMBID: ""
 albumMBID: ""
 artistLink: https://sonnyrollins.com/
+reviewType: gag
 
 ---
 

--- a/data/posts/20210402-reviews-death-from-above-is-4-lovers.md
+++ b/data/posts/20210402-reviews-death-from-above-is-4-lovers.md
@@ -37,6 +37,7 @@ blurb: A rock record produced like a dance record, with endless amounts of satur
 artistMBID: 92dc699f-fcbc-4278-afbe-40b5ad060a55
 albumMBID: 1a44f658-72d1-432d-a3cb-7093a6b71f31
 artistLink: https://www.deathfromabove1979.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20210407-reviews-godspeed-you-black-emperor-gds-pee-at-states-end.md
+++ b/data/posts/20210407-reviews-godspeed-you-black-emperor-gds-pee-at-states-end.md
@@ -35,6 +35,7 @@ blurb: Another commanding and deft iteration of Godspeed’s lauded post-rock st
 artistMBID: 3648db01-b29d-4ab9-835c-83f6a5068fe4
 albumMBID: 3805cfb2-b333-4ed0-a696-019666cca5d7
 artistLink: http://cstrecords.com/artist/godspeed-you-black-emperor/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20210414-reviews-drongo-1.md
+++ b/data/posts/20210414-reviews-drongo-1.md
@@ -37,6 +37,7 @@ blurb: The record takes listeners on a spectacular musical safari, zipping betwe
 artistMBID: fc1aee7d-ed15-496a-a786-31d4ba578060
 albumMBID: 7c9ee4ed-fed1-4bf1-a434-cecb6d15f1a2
 artistLink: https://www.drongotheband.com/
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20210421-reviews-andy-stott-never-the-right-time.md
+++ b/data/posts/20210421-reviews-andy-stott-never-the-right-time.md
@@ -36,6 +36,7 @@ blurb: Where others might layer up to obscene degrees, Stott has a knack for fin
 artistMBID: ecf5ab37-019f-4cc1-9fdc-218de6a41b65
 albumMBID: 966c30c1-1ce4-496d-9c84-0fb9f53527aa
 artistLink: https://www.merchbar.com/dance-electronic-edm/andy-stott
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20210505-reviews-gojira-fortitude.md
+++ b/data/posts/20210505-reviews-gojira-fortitude.md
@@ -33,6 +33,7 @@ blurb: All the great metal albums contain at least a small portion of cheese. Fo
 artistMBID: 1c5efd53-d6b6-4d63-9d22-a15025cf5f07
 albumMBID: 80f680f2-7aeb-4b30-a40b-e6c1e06a010c
 artistLink: https://shop.roadrunnerrecords.co.uk/fr/artists/gojira.html
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20210512-reviews-squid-bright-green-field.md
+++ b/data/posts/20210512-reviews-squid-bright-green-field.md
@@ -38,6 +38,7 @@ blurb: Squid take characteristics from krautrock, dub, funk, and jazz to form a 
 artistMBID: 5422ef5d-00d4-4c7a-81ab-03cb8fc3cc45
 albumMBID: 1cda298d-bffd-40e5-b4b7-a5fc35a3e5a1
 artistLink: https://squiduk.bandcamp.com/merch
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20210519-reviews-st-vincent-daddys-home.md
+++ b/data/posts/20210519-reviews-st-vincent-daddys-home.md
@@ -41,6 +41,7 @@ blurb: Annie Clark wrangles a myriad of vintage sounds and gives them a stunning
 artistMBID: 5334edc0-5faf-4ca5-b1df-000de3e1f752
 albumMBID: 077c9bf8-8958-4e03-b200-addec6b5eafc
 artistLink: https://ilovestvincent.com/
+reviewType: newRelease
 
 ---
 author: andre-dack

--- a/data/posts/20210602-reviews-joni-mitchell-blue.md
+++ b/data/posts/20210602-reviews-joni-mitchell-blue.md
@@ -35,6 +35,7 @@ blurb: The early 1970s was a golden era for singer-songwriters, but this stands 
 artistMBID: a6de8ef9-b1a1-4756-97aa-481bbb8a4069
 albumMBID: 42d725fb-a8b7-388c-8866-3b02789af326
 artistLink: https://jonimitchell.com/music/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20210616-reviews-wolf-alice-blue-weekend.md
+++ b/data/posts/20210616-reviews-wolf-alice-blue-weekend.md
@@ -39,6 +39,7 @@ blurb: Ellie Rowsell’s drift between spoken-word musings and operatic soarings
 artistMBID: 3547f34a-db02-4ab7-b4a0-380e1ef951a9
 albumMBID: 8216c4a1-367e-405e-8d67-9457f6e76c22
 artistLink: https://store.wolfalice.co.uk/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20210623-reviews-the-white-stripes-white-blood-cells.md
+++ b/data/posts/20210623-reviews-the-white-stripes-white-blood-cells.md
@@ -33,6 +33,7 @@ blurb: The record listens like rock music’s answer to an ice-cold six-pack of 
 artistMBID: 11ae9fbb-f3d7-4a47-936f-4c0a04d3b3b5
 albumMBID: c5a0411f-374e-360d-9364-3ddec3007162
 artistLink: https://www.whitestripes.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20210707-reviews-tyler-the-creator-call-me-if-you-get-lost.md
+++ b/data/posts/20210707-reviews-tyler-the-creator-call-me-if-you-get-lost.md
@@ -35,6 +35,8 @@ blurb: The record transcends hip-hop, a buttery fusion of rap, soul, synth-pop, 
 artistMBID: f6beac20-5dfe-4d1f-ae02-0b0a740aafd6
 albumMBID: c65de046-7a48-4269-b4e5-4db0ed328f47
 artistLink: https://golfwang.com/
+reviewType: newRelease
+
 ---
 
 author: andre-dack

--- a/data/posts/20210721-reviews-the-strokes-is-this-it.md
+++ b/data/posts/20210721-reviews-the-strokes-is-this-it.md
@@ -36,6 +36,7 @@ blurb: Each note of every individual performance is captured and presented perfe
 artistMBID: f181961b-20f7-459e-89de-920ef03c7ed0
 albumMBID: efea26d1-a016-30f6-b8e2-bc8c02336b0a
 artistLink: https://shop.thestrokes.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20210728-reviews-kanye-west-donda.md
+++ b/data/posts/20210728-reviews-kanye-west-donda.md
@@ -32,6 +32,7 @@ blurb: TBD
 artistMBID: 164f0d73-1234-4e2c-8743-d77bf2191051
 albumMBID: 00000000-0000-0000
 artistLink: https://shop.kanyewest.com/
+reviewType: gag
 
 ---
 

--- a/data/posts/20210811-reviews-lingua-ignota-sinner-get-ready.md
+++ b/data/posts/20210811-reviews-lingua-ignota-sinner-get-ready.md
@@ -37,6 +37,7 @@ blurb: Uncompromising, and very brutal indeed. Some listeners will struggle to s
 artistMBID: 5d12543f-4b37-4e6f-adb1-0e38f23e04b3
 albumMBID: 68c43ae5-f851-46cb-8edc-a9cacf1125cd
 artistLink: https://linguaignota.net/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20210825-reviews-t-rex-electric-warrior.md
+++ b/data/posts/20210825-reviews-t-rex-electric-warrior.md
@@ -37,6 +37,7 @@ blurb: Romping rock and roll sounded like a breeze for Marc Bolan, and when you 
 artistMBID: c842d29f-a297-48cd-bb71-4f77fd672b16
 albumMBID: e53310bf-8ccc-3d7f-a0b7-5ca4dbababcb
 artistLink: https://www.merchbar.com/rock-alternative/t-rex
+reviewType: retrospective
 
 ---
 author: andre-dack

--- a/data/posts/20210925-reviews-weezer-pinkerton.md
+++ b/data/posts/20210925-reviews-weezer-pinkerton.md
@@ -34,6 +34,7 @@ blurb: Come for the singalong hooks of “El Scorcho”, “Pink Triangle”, an
 artistMBID: 6fe07aa5-fec0-4eca-a456-f29bff451b04
 albumMBID: 385f30e2-0483-355d-aded-23e66aa20f87
 artistLink: https://weezerwebstore.com/
+reviewType: retrospective
 
 ---
 

--- a/data/posts/20211013-reviews-james-blake-friends-that-break-your-heart.md
+++ b/data/posts/20211013-reviews-james-blake-friends-that-break-your-heart.md
@@ -35,6 +35,7 @@ blurb: Blake’s vocals are, predictably, beautiful; Blake’s production is, pr
 artistMBID: 8dc08b1f-e393-4f85-a5dd-300f7693a8b8
 albumMBID: dddf4559-2271-4fb7-90ba-8ae7b4a61af3
 artistLink: https://jamesblake.store/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20211020-reviews-joy-crookes-skin.md
+++ b/data/posts/20211020-reviews-joy-crookes-skin.md
@@ -33,6 +33,7 @@ blurb: Weaving larger-than-life arrangements with razor-sharp yet feather-light 
 artistMBID: 548e9a34-7476-4510-b3cf-70d17106d507
 albumMBID: 185279be-34f3-41b1-97b8-4ddbe98ee2f0
 artistLink: https://shop.joycrookes.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20211103-reviews-mastodon-hushed-and-grim.md
+++ b/data/posts/20211103-reviews-mastodon-hushed-and-grim.md
@@ -31,6 +31,7 @@ blurb: As much fun as its riffs and crunching tone can be, the album feels like 
 artistMBID: bc5e2ad6-0a4a-4d90-b911-e9a7e6861727
 albumMBID: aa4960fb-3b27-4d68-b68a-0143fa5f84f0
 artistLink: https://mastodon.backstreetmerch.com/
+reviewType: newRelease
 
 ---
 

--- a/data/posts/20211124-reviews-idles-crawler.md
+++ b/data/posts/20211124-reviews-idles-crawler.md
@@ -35,6 +35,8 @@ blurb: IDLES’ most considered, sonically thoughtful, and complex release to da
 artistMBID: be465d4f-c28d-4ba1-94ab-ebaada7db8af
 albumMBID: da9a2af4-e97d-43aa-92a9-f8e6c0eab37d
 artistLink: https://www.idlesband.com/shop/
+reviewType: newRelease
+
 ---
 
 author: rachael-davis


### PR DESCRIPTION
With [a basic stats page up and running over on the website](https://github.com/audioxide/website/pull/171), opportunities have begun to appear for our review data to be richer. I hope that, with time, a lot of generic album information (release date, label, etc.) can be fetched using the [MusicBrainz API](https://musicbrainz.org/doc/MusicBrainz_API), but there is some information that is _Audioxide_-specific.

Review type is an example of this. We either review new releases or old ones. Very occasionally we do 'gag' reviews like Simpsons albums or empty Kanye West pages when we get sick of waiting for him to release it. This third type would taint data about averages and the like so they should be filtered out. This can't be automated elsewhere using the album's release date because only we can account for non-serious reviews. (Though as I type I realize an `isGag` value of some kind may have been easier/clearer. Hey ho.)

With this in mind a `reviewType` field has been added to all review files and populated with one of the following strings:

- `newRelease`
- `retrospective`
- `gag`

Once this is merged we'll be able to provide in-depth stats for each type. Hurrah.