### PR TITLE
Rejig local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+EXT_API_URL=http://api.audioxide.com
+API_URL=http://localhost:8888

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .DS_Store
 dist
 .idea
+.parcel-cache
 
 # Local Netlify folder
 .netlify

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-@audioxide:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GITHUB_REGISTRY_TOKEN}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This repository stores the data for the Audioxide API.
 
+## on first install, copy the example .env file and cache the API routes
+
+```
+$ yarn setup-env
+```
+
 ## Layout
 
 ### Data
@@ -142,7 +148,7 @@ to be used in content
 ### Non-data files
 
 - `netlify.toml`
-    - The product of this repository is hosted by Netlify. We use their configuration file format to provide data access only to websites on the audioxide.com domain or subdomains.
+  - The product of this repository is hosted by Netlify. We use their configuration file format to provide data access only to websites on the audioxide.com domain or subdomains.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
   "license": "CC-BY-NC-ND-4.0",
   "private": false,
   "scripts": {
+    "setup-env": "cp .env.example .env",
     "build": "processAudioxideData",
     "dev": "yarn && processAudioxideData && npx http-server dist -p 8888 --cors -c-1"
   },
   "dependencies": {
-    "@audioxide/data-processor": "^0.14.1",
+    "@audioxide/data-processor": "https://github.com/audioxide/data-processor.git",
     "@babel/core": "^7.12.10",
     "flexsearch": "^0.6.32",
     "node-fetch": "^2.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,9 @@
 # yarn lockfile v1
 
 
-"@audioxide/data-processor@^0.13.0":
-  version "0.13.0"
-  resolved "https://npm.pkg.github.com/download/@audioxide/data-processor/0.13.0/52d580e7855ba2cd8cd4442f9ceedb1284a7552ff905c12a8897226f18950c3b#342e2e98a2dae237b6cd4097bef92c09def41451"
-  integrity sha512-bR28a717KnluVXuLXCgqzH3jZ+ljFr5/FFccE5LCNRS1Z6HmUMb6eyghvk1WlhZVaCvfGDDXNklwkhiJJUAjHg==
+"@audioxide/data-processor@https://github.com/audioxide/data-processor.git":
+  version "0.14.1"
+  resolved "https://github.com/audioxide/data-processor.git#19dd98edb19521d3986452cad22ad876f0fe9945"
   dependencies:
     "@parcel/transformer-svgo" "^2.0.0-nightly.1739"
     flexsearch "^0.6.32"


### PR DESCRIPTION
As per @andrewbridge's work in https://github.com/audioxide/website/commit/9d4c56d213e0c1fb7134a8aeaef85f4602ea8368, https://github.com/audioxide/website/commit/a2c0283957438b5779742a32e66bc769873e5f50, and https://github.com/audioxide/website/commit/49706671d5f21de2d4911ababb9d64eea33480c2, this PR refactors local development to not need GitHub keys. The only difference is I've omitted `SEARCH_URL` as it doesn't seem to be used in this repository.

Have run locally and seems to work fine.