### PR TITLE
Add optional fourth colour to review metadata

### DIFF
--- a/data/posts/20150523-reviews-muse-origin-of-symmetry.md
+++ b/data/posts/20150523-reviews-muse-origin-of-symmetry.md
@@ -25,8 +25,9 @@ totalscore:
   fraction: 0.8666666666666667
 colours:
   - "#ea8d0e"
-  - "#ffffff"
-  - "#323944"
+  - "#000000"
+  - "#000000"
+  - "#000000"
 pullquote: Breathless, explosive music
 summary: It’s breathless, explosive music; the kind that compels listeners to pick up an instrument or start a band. Origin of Symmetry listens like a spectacular jam — with all the unpolished, patchy, brazen energy that entails — and all in all it’s pretty rad, man.
 week: 17

--- a/data/posts/20190522-reviews-tyler-the-creator-igor.md
+++ b/data/posts/20190522-reviews-tyler-the-creator-igor.md
@@ -27,6 +27,7 @@ colours:
   - "#f4afc2"
   - "#34302d"
   - "#34302d"
+  - "#34302d"
 pullquote: A good non-rap album
 summary: Tyler deliberately plays against his strengths and manages to push himself to make a good non-rap album. That in itself is pretty fucking fascinating.
 week: 193

--- a/data/posts/20200513-reviews-kraftwerk-the-man-machine.md
+++ b/data/posts/20200513-reviews-kraftwerk-the-man-machine.md
@@ -36,6 +36,7 @@ colours:
   - "#e83c3c"
   - "#181818"
   - "#181818"
+  - "#181818"
 pullquote: Pioneering electronica
 summary: The album makes for hypnotic listening, bobbling along like a well-mannered German robot. All these years later it still sounds like the future.
 week: 233

--- a/data/posts/20200610-reviews-run-the-jewels-rtj4.md
+++ b/data/posts/20200610-reviews-run-the-jewels-rtj4.md
@@ -28,7 +28,7 @@ totalscore:
   fraction: 0.80
 colours:
   - "#da0772"
-  - "#f8b608"
+  - "#1a0f0b"
   - "#1a0f0b"
 pullquote: Boiling point
 summary: "El-P and Mike may have been fighting for the cause before, but now they're on the frontline. On RTJ4, the duo stand up to be counted for what they really are: rappers, producers, activists, husbands, citizens."

--- a/data/posts/20200930-reviews-idles-ultra-mono.md
+++ b/data/posts/20200930-reviews-idles-ultra-mono.md
@@ -29,6 +29,7 @@ colours:
   - "#f2587e"
   - "#090000"
   - "#090000"
+  - "#090000"
 pullquote: A brick through the window of Bullshit Inc
 summary: There is a huge amount of musical and lyrical ingenuity to enjoy here, with strong messages and jovial piss takes. One thing is for certain, Joe Talbot is the town crier, a megaphoned voice of a generation.
 week: 249


### PR DESCRIPTION
As part of an effort to make all our review pages pass WCAG AA colour contrast standards, this adds an optional fourth colour to reviews that will be applied to review summaries if present.

Now, in situations where the primary colour doesn't have sufficient contrast to be used for the summary text, but we still want to have it, we can choose a more suitable colour to fall back on. 

| Before    | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/11598cec-9834-4e46-8dc8-fc43fc778492)  | ![image](https://github.com/user-attachments/assets/4ec1fb31-9a48-4274-b34e-ff37f0bed63f)|

More control, more flexibility, more accessibility. 

The website has also been updated to expect these changes: https://github.com/audioxide/website/pull/191